### PR TITLE
update version of jackson-databind due to security alert

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <protostuff.version>1.6.0</protostuff.version>
     <protobuf.version>3.4.0</protobuf.version>
     <metrics.version>3.1.2</metrics.version>
-    <jackson.version>2.9.6</jackson.version>
+    <jackson.version>2.9.8</jackson.version>
     <log4j.version>2.8.2</log4j.version>
   </properties>
 


### PR DESCRIPTION
CVE-2018-19360 More information
high severity
Vulnerable versions: >= 2.9.0, < 2.9.8
Patched version: 2.9.8
FasterXML jackson-databind 2.x before 2.9.8 might allow attackers to have unspecified impact by leveraging failure to block the axis2-transport-jms class from polymorphic deserialization.

CVE-2018-19362 More information
high severity
Vulnerable versions: >= 2.9.0, < 2.9.8
Patched version: 2.9.8
FasterXML jackson-databind 2.x before 2.9.8 might allow attackers to have unspecified impact by leveraging failure to block the jboss-common-core class from polymorphic deserialization.

CVE-2018-19361 More information
high severity
Vulnerable versions: >= 2.9.0, < 2.9.8
Patched version: 2.9.8
FasterXML jackson-databind 2.x before 2.9.8 might allow attackers to have unspecified impact by leveraging failure to block the openjpa class from polymorphic deserialization.

CVE-2018-14719 More information
high severity
Vulnerable versions: >= 2.9.0, < 2.9.7
Patched version: 2.9.7
FasterXML jackson-databind 2.x before 2.9.7 might allow remote attackers to execute arbitrary code by leveraging failure to block the blaze-ds-opt and blaze-ds-core classes from polymorphic deserialization.

CVE-2018-14720 More information
high severity
Vulnerable versions: >= 2.9.0, < 2.9.7
Patched version: 2.9.7
FasterXML jackson-databind 2.x before 2.9.7 might allow attackers to conduct external XML entity (XXE) attacks by leveraging failure to block unspecified JDK classes from polymorphic deserialization.

CVE-2018-14721 More information
high severity
Vulnerable versions: >= 2.9.0, < 2.9.7
Patched version: 2.9.7
FasterXML jackson-databind 2.x before 2.9.7 might allow remote attackers to conduct server-side request forgery (SSRF) attacks by leveraging failure to block the axis2-jaxws class from polymorphic deserialization.

CVE-2018-14718 More information
high severity
Vulnerable versions: >= 2.9.0, < 2.9.7
Patched version: 2.9.7
FasterXML jackson-databind 2.x before 2.9.7 might allow remote attackers to execute arbitrary code by leveraging failure to block the slf4j-ext class from polymorphic deserialization.