### PR TITLE
Increased default value in TransportImpl.java

### DIFF
--- a/cluster/src/main/java/io/scalecube/cluster/ClusterConfig.java
+++ b/cluster/src/main/java/io/scalecube/cluster/ClusterConfig.java
@@ -372,6 +372,11 @@ public final class ClusterConfig implements FailureDetectorConfig, GossipConfig,
       return this;
     }
 
+    public Builder maxFrameLength(int maxFrameLength) {
+      this.transportConfigBuilder.maxFrameLength(maxFrameLength);
+      return this;
+    }
+
     /**
      * Override the member host in cases when the transport address is not the address to be
      * broadcast.

--- a/transport/src/main/java/io/scalecube/transport/TransportConfig.java
+++ b/transport/src/main/java/io/scalecube/transport/TransportConfig.java
@@ -6,17 +6,20 @@ public final class TransportConfig {
   public static final int DEFAULT_CONNECT_TIMEOUT = 3000;
   public static final boolean DEFAULT_USE_NETWORK_EMULATOR = false;
   public static final MessageCodec DEFAULT_MESSAGE_CODEC = new JacksonMessageCodec();
+  public static final int DEFAULT_MAX_FRAME_LENGTH = 2 * 1024 * 1024; // 2MB
 
   private final int port;
   private final int connectTimeout;
   private final boolean useNetworkEmulator;
   private final MessageCodec messageCodec;
+  private final int maxFrameLength;
 
   private TransportConfig(Builder builder) {
     this.port = builder.port;
     this.connectTimeout = builder.connectTimeout;
     this.useNetworkEmulator = builder.useNetworkEmulator;
     this.messageCodec = builder.messageCodec;
+    this.maxFrameLength = builder.maxFrameLength;
   }
 
   public static TransportConfig defaultConfig() {
@@ -43,6 +46,10 @@ public final class TransportConfig {
     return messageCodec;
   }
 
+  public int getMaxFrameLength() {
+    return maxFrameLength;
+  }
+
   @Override
   public String toString() {
     return "TransportConfig{port="
@@ -53,6 +60,8 @@ public final class TransportConfig {
         + useNetworkEmulator
         + ", messageCodec="
         + messageCodec
+        + ", maxFrameLength="
+        + maxFrameLength
         + '}';
   }
 
@@ -62,6 +71,7 @@ public final class TransportConfig {
     private boolean useNetworkEmulator = DEFAULT_USE_NETWORK_EMULATOR;
     private int connectTimeout = DEFAULT_CONNECT_TIMEOUT;
     private MessageCodec messageCodec = DEFAULT_MESSAGE_CODEC;
+    private int maxFrameLength = DEFAULT_MAX_FRAME_LENGTH;
 
     private Builder() {}
 
@@ -75,6 +85,7 @@ public final class TransportConfig {
       this.connectTimeout = config.connectTimeout;
       this.useNetworkEmulator = config.useNetworkEmulator;
       this.messageCodec = config.messageCodec;
+      this.maxFrameLength = config.maxFrameLength;
       return this;
     }
 
@@ -95,6 +106,11 @@ public final class TransportConfig {
 
     public Builder messageCodec(MessageCodec messageCodec) {
       this.messageCodec = messageCodec;
+      return this;
+    }
+
+    public Builder maxFrameLength(int maxFrameLength) {
+      this.maxFrameLength = maxFrameLength;
       return this;
     }
 

--- a/transport/src/main/java/io/scalecube/transport/TransportImpl.java
+++ b/transport/src/main/java/io/scalecube/transport/TransportImpl.java
@@ -369,8 +369,8 @@ final class TransportImpl implements Transport {
   private final class TransportChannelInitializer
       implements BiConsumer<ConnectionObserver, Channel> {
 
-    private static final int MAX_FRAME_LENGTH = 8192;
-    private static final int LENGTH_FIELD_LENGTH = 2;
+    private static final int MAX_FRAME_LENGTH = 2 * 1024 * 1024; // 2MB
+    private static final int LENGTH_FIELD_LENGTH = 3;
 
     @Override
     public void accept(ConnectionObserver connectionObserver, Channel channel) {

--- a/transport/src/main/java/io/scalecube/transport/TransportImpl.java
+++ b/transport/src/main/java/io/scalecube/transport/TransportImpl.java
@@ -370,7 +370,7 @@ final class TransportImpl implements Transport {
       implements BiConsumer<ConnectionObserver, Channel> {
 
     private static final int MAX_FRAME_LENGTH = 2 * 1024 * 1024; // 2MB
-    private static final int LENGTH_FIELD_LENGTH = 3;
+    private static final int LENGTH_FIELD_LENGTH = 4;
 
     @Override
     public void accept(ConnectionObserver connectionObserver, Channel channel) {

--- a/transport/src/main/java/io/scalecube/transport/TransportImpl.java
+++ b/transport/src/main/java/io/scalecube/transport/TransportImpl.java
@@ -369,7 +369,6 @@ final class TransportImpl implements Transport {
   private final class TransportChannelInitializer
       implements BiConsumer<ConnectionObserver, Channel> {
 
-    private static final int MAX_FRAME_LENGTH = 2 * 1024 * 1024; // 2MB
     private static final int LENGTH_FIELD_LENGTH = 4;
 
     @Override
@@ -378,7 +377,7 @@ final class TransportImpl implements Transport {
       pipeline.addLast(new LengthFieldPrepender(LENGTH_FIELD_LENGTH));
       pipeline.addLast(
           new LengthFieldBasedFrameDecoder(
-              MAX_FRAME_LENGTH, 0, LENGTH_FIELD_LENGTH, 0, LENGTH_FIELD_LENGTH));
+              config.getMaxFrameLength(), 0, LENGTH_FIELD_LENGTH, 0, LENGTH_FIELD_LENGTH));
       pipeline.addLast(exceptionHandler);
     }
   }

--- a/transport/src/test/java/io/scalecube/transport/TransportTestUtils.java
+++ b/transport/src/test/java/io/scalecube/transport/TransportTestUtils.java
@@ -5,6 +5,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 
+import static io.scalecube.transport.TransportConfig.DEFAULT_MAX_FRAME_LENGTH;
+
 /** Transport test utility class. */
 public final class TransportTestUtils {
 
@@ -23,7 +25,11 @@ public final class TransportTestUtils {
    */
   public static Transport createTransport() {
     TransportConfig config =
-        TransportConfig.builder().connectTimeout(CONNECT_TIMEOUT).useNetworkEmulator(true).build();
+        TransportConfig.builder()
+          .connectTimeout(CONNECT_TIMEOUT)
+          .useNetworkEmulator(true)
+          .maxFrameLength(DEFAULT_MAX_FRAME_LENGTH)
+          .build();
     return Transport.bindAwait(config);
   }
 


### PR DESCRIPTION
Increased the max frame length size in the LengthFieldBasedFrameDecoder to avoid TooLongFrameExceptions.

Because my messages are big, and causing:
2019-02-28 10:38:53 [sc-cluster-io-epoll-1] WARN   i.s.transport.ExceptionHandler - Exception caught for channel [id: 0x442a99a9, L:/10.X.X.X:8802! R:/10.X.X.X:45340], io.netty.handler.codec.TooLongFrameException: Adjusted frame length exceeds 8192: 25188 - discarded
io.netty.handler.codec.TooLongFrameException: Adjusted frame length exceeds 8192: 25188 - discarded
        at io.netty.handler.codec.LengthFieldBasedFrameDecoder.fail(LengthFieldBasedFrameDecoder.java:522)
        at io.netty.handler.codec.LengthFieldBasedFrameDecoder.failIfNecessary(LengthFieldBasedFrameDecoder.java:495)
        at io.netty.handler.codec.LengthFieldBasedFrameDecoder.exceededFrameLength(LengthFieldBasedFrameDecoder.java:387)
        at io.netty.handler.codec.LengthFieldBasedFrameDecoder.decode(LengthFieldBasedFrameDecoder.java:430)
        at io.netty.handler.codec.LengthFieldBasedFrameDecoder.decode(LengthFieldBasedFrameDecoder.java:343)
        at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:502)
        at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:441)
        at io.netty.handler.codec.ByteToMessageDecoder.channelInputClosed(ByteToMessageDecoder.java:405)
        at io.netty.handler.codec.ByteToMessageDecoder.channelInputClosed(ByteToMessageDecoder.java:372)
        at io.netty.handler.codec.ByteToMessageDecoder.channelInactive(ByteToMessageDecoder.java:355)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:224)
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelInactive(DefaultChannelPipeline.java:1429)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:245)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:231)
        at io.netty.channel.DefaultChannelPipeline.fireChannelInactive(DefaultChannelPipeline.java:947)
        at io.netty.channel.AbstractChannel$AbstractUnsafe$8.run(AbstractChannel.java:822)
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163)
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404)
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:335)
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:897)
        at java.lang.Thread.run(Thread.java:748)