### PR TITLE
Cluster member name alias in addition to

### DIFF
--- a/cluster-api/src/main/java/io/scalecube/cluster/ClusterConfig.java
+++ b/cluster-api/src/main/java/io/scalecube/cluster/ClusterConfig.java
@@ -7,6 +7,7 @@ import io.scalecube.cluster.metadata.MetadataDecoder;
 import io.scalecube.cluster.metadata.MetadataEncoder;
 import io.scalecube.cluster.transport.api.TransportConfig;
 import java.util.Optional;
+import java.util.StringJoiner;
 import java.util.function.UnaryOperator;
 import reactor.core.Exceptions;
 
@@ -34,6 +35,7 @@ public final class ClusterConfig implements Cloneable {
   private MetadataEncoder metadataEncoder = MetadataEncoder.INSTANCE;
   private MetadataDecoder metadataDecoder = MetadataDecoder.INSTANCE;
 
+  private String memberId;
   private String memberHost;
   private Integer memberPort;
 
@@ -158,11 +160,27 @@ public final class ClusterConfig implements Cloneable {
    * Sets a memberHost.
    *
    * @param memberHost member host
-   * @return new {@code ClusterConfig} instance@return
+   * @return new {@code ClusterConfig} instance
    */
   public ClusterConfig memberHost(String memberHost) {
     ClusterConfig c = clone();
     c.memberHost = memberHost;
+    return c;
+  }
+
+  public String memberId() {
+    return memberId;
+  }
+
+  /**
+   * Sets a memberId.
+   *
+   * @param memberId member id
+   * @return new {@code ClusterConfig} instance
+   */
+  public ClusterConfig memberId(String memberId) {
+    ClusterConfig c = clone();
+    c.memberId = memberId;
     return c;
   }
 
@@ -262,29 +280,19 @@ public final class ClusterConfig implements Cloneable {
 
   @Override
   public String toString() {
-    return "ClusterConfig{"
-        + "metadata="
-        + metadataAsString()
-        + ", metadataTimeout="
-        + metadataTimeout
-        + ", metadataEncoder="
-        + metadataEncoder
-        + ", metadataDecoder="
-        + metadataDecoder
-        + ", memberHost='"
-        + memberHost
-        + '\''
-        + ", memberPort="
-        + memberPort
-        + ", transportConfig="
-        + transportConfig
-        + ", failureDetectorConfig="
-        + failureDetectorConfig
-        + ", gossipConfig="
-        + gossipConfig
-        + ", membershipConfig="
-        + membershipConfig
-        + '}';
+    return new StringJoiner(", ", ClusterConfig.class.getSimpleName() + "[", "]")
+        .add("metadata=" + metadataAsString())
+        .add("metadataTimeout=" + metadataTimeout)
+        .add("metadataEncoder=" + metadataEncoder)
+        .add("metadataDecoder=" + metadataDecoder)
+        .add("memberId='" + memberId + "'")
+        .add("memberHost='" + memberHost + "'")
+        .add("memberPort=" + memberPort)
+        .add("transportConfig=" + transportConfig)
+        .add("failureDetectorConfig=" + failureDetectorConfig)
+        .add("gossipConfig=" + gossipConfig)
+        .add("membershipConfig=" + membershipConfig)
+        .toString();
   }
 
   private String metadataAsString() {

--- a/cluster-api/src/main/java/io/scalecube/cluster/Member.java
+++ b/cluster-api/src/main/java/io/scalecube/cluster/Member.java
@@ -68,6 +68,6 @@ public final class Member {
 
   @Override
   public String toString() {
-    return id + "@" + address;
+    return id + ":" + address.port();
   }
 }

--- a/cluster-api/src/main/java/io/scalecube/cluster/fdetector/FailureDetectorConfig.java
+++ b/cluster-api/src/main/java/io/scalecube/cluster/fdetector/FailureDetectorConfig.java
@@ -1,5 +1,6 @@
 package io.scalecube.cluster.fdetector;
 
+import java.util.StringJoiner;
 import reactor.core.Exceptions;
 
 public final class FailureDetectorConfig implements Cloneable {
@@ -121,13 +122,10 @@ public final class FailureDetectorConfig implements Cloneable {
 
   @Override
   public String toString() {
-    return "FailureDetectorConfig{"
-        + "pingInterval="
-        + pingInterval
-        + ", pingTimeout="
-        + pingTimeout
-        + ", pingReqMembers="
-        + pingReqMembers
-        + '}';
+    return new StringJoiner(", ", FailureDetectorConfig.class.getSimpleName() + "[", "]")
+        .add("pingInterval=" + pingInterval)
+        .add("pingTimeout=" + pingTimeout)
+        .add("pingReqMembers=" + pingReqMembers)
+        .toString();
   }
 }

--- a/cluster-api/src/main/java/io/scalecube/cluster/gossip/GossipConfig.java
+++ b/cluster-api/src/main/java/io/scalecube/cluster/gossip/GossipConfig.java
@@ -1,5 +1,6 @@
 package io.scalecube.cluster.gossip;
 
+import java.util.StringJoiner;
 import reactor.core.Exceptions;
 
 public final class GossipConfig implements Cloneable {
@@ -115,13 +116,10 @@ public final class GossipConfig implements Cloneable {
 
   @Override
   public String toString() {
-    return "GossipConfig{"
-        + "gossipFanout="
-        + gossipFanout
-        + ", gossipInterval="
-        + gossipInterval
-        + ", gossipRepeatMult="
-        + gossipRepeatMult
-        + '}';
+    return new StringJoiner(", ", GossipConfig.class.getSimpleName() + "[", "]")
+        .add("gossipFanout=" + gossipFanout)
+        .add("gossipInterval=" + gossipInterval)
+        .add("gossipRepeatMult=" + gossipRepeatMult)
+        .toString();
   }
 }

--- a/cluster-api/src/main/java/io/scalecube/cluster/membership/MembershipConfig.java
+++ b/cluster-api/src/main/java/io/scalecube/cluster/membership/MembershipConfig.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.StringJoiner;
 import reactor.core.Exceptions;
 
 public final class MembershipConfig implements Cloneable {
@@ -167,18 +168,12 @@ public final class MembershipConfig implements Cloneable {
 
   @Override
   public String toString() {
-    return "MembershipConfig{"
-        + "seedMembers="
-        + seedMembers
-        + ", syncInterval="
-        + syncInterval
-        + ", syncTimeout="
-        + syncTimeout
-        + ", suspicionMult="
-        + suspicionMult
-        + ", syncGroup='"
-        + syncGroup
-        + '\''
-        + '}';
+    return new StringJoiner(", ", MembershipConfig.class.getSimpleName() + "[", "]")
+        .add("seedMembers=" + seedMembers)
+        .add("syncInterval=" + syncInterval)
+        .add("syncTimeout=" + syncTimeout)
+        .add("suspicionMult=" + suspicionMult)
+        .add("syncGroup='" + syncGroup + "'")
+        .toString();
   }
 }

--- a/cluster-api/src/main/java/io/scalecube/cluster/membership/MembershipEvent.java
+++ b/cluster-api/src/main/java/io/scalecube/cluster/membership/MembershipEvent.java
@@ -3,6 +3,7 @@ package io.scalecube.cluster.membership;
 import io.scalecube.cluster.Member;
 import java.nio.ByteBuffer;
 import java.util.Objects;
+import java.util.StringJoiner;
 
 /**
  * Event which is emitted on cluster membership changes when new member added, updated in the
@@ -97,15 +98,12 @@ public final class MembershipEvent {
 
   @Override
   public String toString() {
-    return "MembershipEvent{type="
-        + type
-        + ", member="
-        + member
-        + ", newMetadata="
-        + metadataAsString(newMetadata)
-        + ", oldMetadata="
-        + metadataAsString(oldMetadata)
-        + '}';
+    return new StringJoiner(", ", MembershipEvent.class.getSimpleName() + "[", "]")
+        .add("type=" + type)
+        .add("member=" + member)
+        .add("oldMetadata=" + metadataAsString(oldMetadata))
+        .add("newMetadata=" + metadataAsString(newMetadata))
+        .toString();
   }
 
   private String metadataAsString(ByteBuffer metadata) {

--- a/cluster-testlib/src/main/java/io/scalecube/cluster/utils/NetworkEmulator.java
+++ b/cluster-testlib/src/main/java/io/scalecube/cluster/utils/NetworkEmulator.java
@@ -6,6 +6,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
+import java.util.StringJoiner;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
@@ -369,7 +370,10 @@ public final class NetworkEmulator {
 
     @Override
     public String toString() {
-      return "OutboundSettings{loss=" + lossPercent + ", delay=" + meanDelay + '}';
+      return new StringJoiner(", ", OutboundSettings.class.getSimpleName() + "[", "]")
+          .add("lossPercent=" + lossPercent)
+          .add("meanDelay=" + meanDelay)
+          .toString();
     }
   }
 
@@ -405,7 +409,9 @@ public final class NetworkEmulator {
 
     @Override
     public String toString() {
-      return "InboundSettings{shallPass=" + shallPass + '}';
+      return new StringJoiner(", ", InboundSettings.class.getSimpleName() + "[", "]")
+          .add("shallPass=" + shallPass)
+          .toString();
     }
   }
 }

--- a/cluster/src/main/java/io/scalecube/cluster/ClusterImpl.java
+++ b/cluster/src/main/java/io/scalecube/cluster/ClusterImpl.java
@@ -340,7 +340,11 @@ public final class ClusterImpl implements Cluster {
             .map(memberHost -> Address.create(memberHost, port))
             .orElseGet(() -> Address.create(localAddress, listenPort));
 
-    return new Member(memberAddress);
+    if (config.memberId() != null) {
+      return new Member(config.memberId(), memberAddress);
+    } else {
+      return new Member(memberAddress);
+    }
   }
 
   @Override

--- a/cluster/src/main/java/io/scalecube/cluster/ClusterImpl.java
+++ b/cluster/src/main/java/io/scalecube/cluster/ClusterImpl.java
@@ -42,7 +42,7 @@ import reactor.core.scheduler.Schedulers;
 /** Cluster implementation. */
 public final class ClusterImpl implements Cluster {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(ClusterImpl.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(Cluster.class);
 
   private static final Set<String> SYSTEM_MESSAGES =
       Collections.unmodifiableSet(
@@ -433,7 +433,7 @@ public final class ClusterImpl implements Cluster {
     return Mono.defer(
         () -> {
           LOGGER.info("Cluster member {} is shutting down", localMember);
-          return Flux.concatDelayError(leaveCluster(localMember), dispose(), transport.stop())
+          return Flux.concatDelayError(leaveCluster(), dispose(), transport.stop())
               .then()
               .doFinally(s -> scheduler.dispose())
               .doOnSuccess(
@@ -445,21 +445,15 @@ public final class ClusterImpl implements Cluster {
         });
   }
 
-  private Mono<Void> leaveCluster(Member member) {
+  private Mono<Void> leaveCluster() {
     return membership
         .leaveCluster()
         .subscribeOn(scheduler)
-        .doOnSuccess(
-            s ->
-                LOGGER.debug(
-                    "Cluster member {} notified about his leaving and shutting down", member))
+        .doOnSuccess(s -> LOGGER.debug("Cluster member {} has left a cluster", localMember))
         .doOnError(
             ex ->
                 LOGGER.info(
-                    "Cluster member {} failed to spread leave notification "
-                        + "to other cluster members: {}",
-                    member,
-                    ex.toString()))
+                    "Cluster member {} failed on leaveCluster: {}", localMember, ex.toString()))
         .then();
   }
 
@@ -489,9 +483,9 @@ public final class ClusterImpl implements Cluster {
 
   public interface MonitorMBean {
 
-    Collection<String> getMember();
+    Collection<String> getMemberId();
 
-    String getMemberAsString();
+    String getMemberIdAsString();
 
     Collection<String> getMetadata();
 
@@ -517,13 +511,13 @@ public final class ClusterImpl implements Cluster {
     }
 
     @Override
-    public Collection<String> getMember() {
+    public Collection<String> getMemberId() {
       return Collections.singleton(cluster.member().id());
     }
 
     @Override
-    public String getMemberAsString() {
-      return getMember().iterator().next();
+    public String getMemberIdAsString() {
+      return getMemberId().iterator().next();
     }
 
     @Override

--- a/cluster/src/main/java/io/scalecube/cluster/fdetector/FailureDetectorEvent.java
+++ b/cluster/src/main/java/io/scalecube/cluster/fdetector/FailureDetectorEvent.java
@@ -2,6 +2,7 @@ package io.scalecube.cluster.fdetector;
 
 import io.scalecube.cluster.Member;
 import io.scalecube.cluster.membership.MemberStatus;
+import java.util.StringJoiner;
 
 /** CLass contains result of ping check. */
 public final class FailureDetectorEvent {
@@ -24,6 +25,9 @@ public final class FailureDetectorEvent {
 
   @Override
   public String toString() {
-    return "FailureDetectorEvent{member=" + member + ", status=" + status + '}';
+    return new StringJoiner(", ", FailureDetectorEvent.class.getSimpleName() + "[", "]")
+        .add("member=" + member)
+        .add("status=" + status)
+        .toString();
   }
 }

--- a/cluster/src/main/java/io/scalecube/cluster/fdetector/FailureDetectorImpl.java
+++ b/cluster/src/main/java/io/scalecube/cluster/fdetector/FailureDetectorImpl.java
@@ -28,7 +28,7 @@ import reactor.core.scheduler.Scheduler;
 
 public final class FailureDetectorImpl implements FailureDetector {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(FailureDetectorImpl.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(FailureDetector.class);
 
   // Qualifiers
 

--- a/cluster/src/main/java/io/scalecube/cluster/fdetector/PingData.java
+++ b/cluster/src/main/java/io/scalecube/cluster/fdetector/PingData.java
@@ -1,6 +1,7 @@
 package io.scalecube.cluster.fdetector;
 
 import io.scalecube.cluster.Member;
+import java.util.StringJoiner;
 
 /** DTO class. Supports FailureDetector messages (Ping, Ack, PingReq). */
 final class PingData {
@@ -79,15 +80,11 @@ final class PingData {
 
   @Override
   public String toString() {
-    return "PingData{"
-        + "from="
-        + from
-        + ", to="
-        + to
-        + ", originalIssuer="
-        + originalIssuer
-        + ", ackType="
-        + ackType
-        + '}';
+    return new StringJoiner(", ", PingData.class.getSimpleName() + "[", "]")
+        .add("from=" + from)
+        .add("to=" + to)
+        .add("originalIssuer=" + originalIssuer)
+        .add("ackType=" + ackType)
+        .toString();
   }
 }

--- a/cluster/src/main/java/io/scalecube/cluster/gossip/Gossip.java
+++ b/cluster/src/main/java/io/scalecube/cluster/gossip/Gossip.java
@@ -2,6 +2,7 @@ package io.scalecube.cluster.gossip;
 
 import io.scalecube.cluster.transport.api.Message;
 import java.util.Objects;
+import java.util.StringJoiner;
 
 /** Data model for gossip, include gossip id, qualifier and object need to disseminate. */
 final class Gossip {
@@ -44,6 +45,9 @@ final class Gossip {
 
   @Override
   public String toString() {
-    return "Gossip{gossipId=" + gossipId + ", message=" + message + '}';
+    return new StringJoiner(", ", Gossip.class.getSimpleName() + "[", "]")
+        .add("gossipId='" + gossipId + "'")
+        .add("message=" + message)
+        .toString();
   }
 }

--- a/cluster/src/main/java/io/scalecube/cluster/gossip/GossipRequest.java
+++ b/cluster/src/main/java/io/scalecube/cluster/gossip/GossipRequest.java
@@ -3,6 +3,7 @@ package io.scalecube.cluster.gossip;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.StringJoiner;
 
 /** Gossip request which be transmitted through the network, contains list of gossips. */
 final class GossipRequest {
@@ -32,6 +33,9 @@ final class GossipRequest {
 
   @Override
   public String toString() {
-    return "GossipRequest{gossips=" + gossips + ", from=" + from + '}';
+    return new StringJoiner(", ", GossipRequest.class.getSimpleName() + "[", "]")
+        .add("gossips=" + gossips)
+        .add("from='" + from + "'")
+        .toString();
   }
 }

--- a/cluster/src/main/java/io/scalecube/cluster/gossip/GossipState.java
+++ b/cluster/src/main/java/io/scalecube/cluster/gossip/GossipState.java
@@ -3,6 +3,7 @@ package io.scalecube.cluster.gossip;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.StringJoiner;
 
 /** Data related to gossip, maintained locally on each node. */
 final class GossipState {
@@ -39,12 +40,10 @@ final class GossipState {
 
   @Override
   public String toString() {
-    return "GossipState{gossip="
-        + gossip
-        + ", infectionPeriod="
-        + infectionPeriod
-        + ", infected="
-        + infected
-        + '}';
+    return new StringJoiner(", ", GossipState.class.getSimpleName() + "[", "]")
+        .add("gossip=" + gossip)
+        .add("infectionPeriod=" + infectionPeriod)
+        .add("infected=" + infected)
+        .toString();
   }
 }

--- a/cluster/src/main/java/io/scalecube/cluster/membership/MembershipPingData.java
+++ b/cluster/src/main/java/io/scalecube/cluster/membership/MembershipPingData.java
@@ -1,6 +1,7 @@
 package io.scalecube.cluster.membership;
 
 import io.scalecube.cluster.Member;
+import java.util.StringJoiner;
 
 final class MembershipPingData {
   /** Message's destination address. */
@@ -19,9 +20,8 @@ final class MembershipPingData {
 
   @Override
   public String toString() {
-    final StringBuilder sb = new StringBuilder("MembershipPingData{");
-    sb.append("target=").append(target);
-    sb.append('}');
-    return sb.toString();
+    return new StringJoiner(", ", MembershipPingData.class.getSimpleName() + "[", "]")
+        .add("target=" + target)
+        .toString();
   }
 }

--- a/cluster/src/main/java/io/scalecube/cluster/membership/MembershipProtocolImpl.java
+++ b/cluster/src/main/java/io/scalecube/cluster/membership/MembershipProtocolImpl.java
@@ -51,7 +51,7 @@ import reactor.core.scheduler.Scheduler;
 
 public final class MembershipProtocolImpl implements MembershipProtocol {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(MembershipProtocolImpl.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(MembershipProtocol.class);
   private static final Logger LOGGER_MEMBERSHIP =
       LoggerFactory.getLogger("io.scalecube.cluster.Membership");
 

--- a/cluster/src/main/java/io/scalecube/cluster/membership/SyncData.java
+++ b/cluster/src/main/java/io/scalecube/cluster/membership/SyncData.java
@@ -3,6 +3,7 @@ package io.scalecube.cluster.membership;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.StringJoiner;
 
 /**
  * A class containing full membership table from specific member and used full synchronization
@@ -36,6 +37,9 @@ final class SyncData {
 
   @Override
   public String toString() {
-    return "SyncData{membership=" + membership + ", syncGroup=" + syncGroup + '}';
+    return new StringJoiner(", ", SyncData.class.getSimpleName() + "[", "]")
+        .add("membership=" + membership)
+        .add("syncGroup='" + syncGroup + "'")
+        .toString();
   }
 }

--- a/cluster/src/main/java/io/scalecube/cluster/metadata/GetMetadataRequest.java
+++ b/cluster/src/main/java/io/scalecube/cluster/metadata/GetMetadataRequest.java
@@ -2,6 +2,7 @@ package io.scalecube.cluster.metadata;
 
 import io.scalecube.cluster.Member;
 import java.util.Objects;
+import java.util.StringJoiner;
 
 /** DTO class. Stands for remote request on getting metadata in remote MetadataStore. */
 final class GetMetadataRequest {
@@ -22,6 +23,8 @@ final class GetMetadataRequest {
 
   @Override
   public String toString() {
-    return "GetMetadataRequest{" + "member=" + member + '}';
+    return new StringJoiner(", ", GetMetadataRequest.class.getSimpleName() + "[", "]")
+        .add("member=" + member)
+        .toString();
   }
 }

--- a/cluster/src/main/java/io/scalecube/cluster/metadata/GetMetadataResponse.java
+++ b/cluster/src/main/java/io/scalecube/cluster/metadata/GetMetadataResponse.java
@@ -2,6 +2,7 @@ package io.scalecube.cluster.metadata;
 
 import io.scalecube.cluster.Member;
 import java.nio.ByteBuffer;
+import java.util.StringJoiner;
 
 /**
  * DTO class. Stands for response for preceding remote request on getting metadata in remote
@@ -33,6 +34,9 @@ final class GetMetadataResponse {
 
   @Override
   public String toString() {
-    return "GetMetadataResponse{" + "member=" + member + ", metadata=" + metadata.remaining() + '}';
+    return new StringJoiner(", ", GetMetadataResponse.class.getSimpleName() + "[", "]")
+        .add("member=" + member)
+        .add("metadata=" + metadata.remaining())
+        .toString();
   }
 }

--- a/cluster/src/main/java/io/scalecube/cluster/metadata/MetadataStoreImpl.java
+++ b/cluster/src/main/java/io/scalecube/cluster/metadata/MetadataStoreImpl.java
@@ -21,7 +21,7 @@ import reactor.core.scheduler.Scheduler;
 
 public class MetadataStoreImpl implements MetadataStore {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(MetadataStoreImpl.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(MetadataStore.class);
 
   // Qualifiers
 

--- a/cluster/src/test/resources/log4j2-test.xml
+++ b/cluster/src/test/resources/log4j2-test.xml
@@ -10,13 +10,13 @@
   </Appenders>
 
   <Loggers>
-    <Logger name="io.netty" level="trace"/>
-    <Logger name="reactor.netty" level="trace"/>
-    <Logger name="io.scalecube.transport" level="trace"/>
-    <Logger name="io.scalecube.cluster" level="trace"/>
-    <Logger name="io.scalecube.services" level="trace"/>
+    <Logger name="io.netty" level="info"/>
+    <Logger name="reactor.netty" level="info"/>
+    <Logger name="io.scalecube.transport" level="info"/>
+    <Logger name="io.scalecube.cluster" level="info"/>
+    <Logger name="io.scalecube.services" level="info"/>
 
-    <Root level="trace">
+    <Root level="info">
       <AppenderRef ref="console"/>
     </Root>
   </Loggers>

--- a/cluster/src/test/resources/log4j2-test.xml
+++ b/cluster/src/test/resources/log4j2-test.xml
@@ -10,13 +10,13 @@
   </Appenders>
 
   <Loggers>
-    <Logger name="io.netty" level="info"/>
-    <Logger name="reactor.netty" level="info"/>
-    <Logger name="io.scalecube.transport" level="info"/>
-    <Logger name="io.scalecube.cluster" level="info"/>
-    <Logger name="io.scalecube.services" level="info"/>
+    <Logger name="io.netty" level="trace"/>
+    <Logger name="reactor.netty" level="trace"/>
+    <Logger name="io.scalecube.transport" level="trace"/>
+    <Logger name="io.scalecube.cluster" level="trace"/>
+    <Logger name="io.scalecube.services" level="trace"/>
 
-    <Root level="info">
+    <Root level="trace">
       <AppenderRef ref="console"/>
     </Root>
   </Loggers>

--- a/transport-parent/transport-api/src/main/java/io/scalecube/cluster/transport/api/Message.java
+++ b/transport-parent/transport-api/src/main/java/io/scalecube/cluster/transport/api/Message.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.StringJoiner;
 
 /**
  * The Class Message introduces generic protocol used for point to point communication by transport.
@@ -184,7 +185,11 @@ public final class Message {
 
   @Override
   public String toString() {
-    return "Message {headers: " + headers + ", sender: " + sender + ", data: " + data + '}';
+    return new StringJoiner(", ", Message.class.getSimpleName() + "[", "]")
+        .add("sender=" + sender)
+        .add("headers=" + headers)
+        .add("data=" + data)
+        .toString();
   }
 
   public static class Builder {

--- a/transport-parent/transport-api/src/main/java/io/scalecube/cluster/transport/api/TransportConfig.java
+++ b/transport-parent/transport-api/src/main/java/io/scalecube/cluster/transport/api/TransportConfig.java
@@ -1,5 +1,6 @@
 package io.scalecube.cluster.transport.api;
 
+import java.util.StringJoiner;
 import reactor.core.Exceptions;
 
 public final class TransportConfig implements Cloneable {
@@ -143,17 +144,12 @@ public final class TransportConfig implements Cloneable {
 
   @Override
   public String toString() {
-    return "TransportConfig{"
-        + "host="
-        + host
-        + ", port="
-        + port
-        + ", connectTimeout="
-        + connectTimeout
-        + ", messageCodec="
-        + messageCodec
-        + ", maxFrameLength="
-        + maxFrameLength
-        + '}';
+    return new StringJoiner(", ", TransportConfig.class.getSimpleName() + "[", "]")
+        .add("host='" + host + "'")
+        .add("port=" + port)
+        .add("connectTimeout=" + connectTimeout)
+        .add("messageCodec=" + messageCodec)
+        .add("maxFrameLength=" + maxFrameLength)
+        .toString();
   }
 }

--- a/transport-parent/transport-netty/src/main/java/io/scalecube/transport/netty/TransportImpl.java
+++ b/transport-parent/transport-netty/src/main/java/io/scalecube/transport/netty/TransportImpl.java
@@ -44,7 +44,7 @@ import reactor.netty.tcp.TcpServer;
 
 public final class TransportImpl implements Transport {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(TransportImpl.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(Transport.class);
 
   private final TransportConfig config;
   private final LoopResources loopResources;


### PR DESCRIPTION
Fixes https://github.com/scalecube/scalecube-cluster/issues/252

**Updates**
- Added `memberId` property string at `ClusterConfig`. By default it's set to null, once set to not null overrides default one of the cluster (which 's  `ClusterImpl.generateId()`)
- Updated toString-s  all around code base.