### PR TITLE
Upgrade to Jackson 2.10.0

### DIFF
--- a/codec-parent/codec-jackson-smile/pom.xml
+++ b/codec-parent/codec-jackson-smile/pom.xml
@@ -28,6 +28,10 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/codec-parent/codec-jackson-smile/src/main/java/io/scalecube/cluster/codec/jackson/smile/DefaultObjectMapper.java
+++ b/codec-parent/codec-jackson-smile/src/main/java/io/scalecube/cluster/codec/jackson/smile/DefaultObjectMapper.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 final class DefaultObjectMapper {
 

--- a/codec-parent/codec-jackson-smile/src/main/java/io/scalecube/cluster/codec/jackson/smile/DefaultObjectMapper.java
+++ b/codec-parent/codec-jackson-smile/src/main/java/io/scalecube/cluster/codec/jackson/smile/DefaultObjectMapper.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 
-final class DefaultObjectMapper {
+public final class DefaultObjectMapper {
 
   public static final ObjectMapper OBJECT_MAPPER = initMapper();
 

--- a/codec-parent/codec-jackson-smile/src/main/java/io/scalecube/cluster/codec/jackson/smile/DefaultObjectMapper.java
+++ b/codec-parent/codec-jackson-smile/src/main/java/io/scalecube/cluster/codec/jackson/smile/DefaultObjectMapper.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 
-public final class DefaultObjectMapper {
+final class DefaultObjectMapper {
 
   public static final ObjectMapper OBJECT_MAPPER = initMapper();
 

--- a/codec-parent/codec-jackson-smile/src/main/java/io/scalecube/cluster/codec/jackson/smile/DefaultObjectMapper.java
+++ b/codec-parent/codec-jackson-smile/src/main/java/io/scalecube/cluster/codec/jackson/smile/DefaultObjectMapper.java
@@ -28,7 +28,7 @@ final class DefaultObjectMapper {
     mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
     mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     mapper.configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
-    mapper.enableDefaultTyping(
+    mapper.activateDefaultTyping(
         LaissezFaireSubTypeValidator.instance,
         DefaultTyping.JAVA_LANG_OBJECT,
         JsonTypeInfo.As.WRAPPER_OBJECT);

--- a/codec-parent/codec-jackson-smile/src/main/java/io/scalecube/cluster/codec/jackson/smile/DefaultObjectMapper.java
+++ b/codec-parent/codec-jackson-smile/src/main/java/io/scalecube/cluster/codec/jackson/smile/DefaultObjectMapper.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 final class DefaultObjectMapper {
 
@@ -32,6 +33,7 @@ final class DefaultObjectMapper {
         LaissezFaireSubTypeValidator.instance,
         DefaultTyping.JAVA_LANG_OBJECT,
         JsonTypeInfo.As.WRAPPER_OBJECT);
+    mapper.registerModule(new Jdk8Module());
     return mapper;
   }
 }

--- a/codec-parent/codec-jackson-smile/src/main/java/io/scalecube/cluster/codec/jackson/smile/DefaultObjectMapper.java
+++ b/codec-parent/codec-jackson-smile/src/main/java/io/scalecube/cluster/codec/jackson/smile/DefaultObjectMapper.java
@@ -33,7 +33,7 @@ final class DefaultObjectMapper {
         LaissezFaireSubTypeValidator.instance,
         DefaultTyping.JAVA_LANG_OBJECT,
         JsonTypeInfo.As.WRAPPER_OBJECT);
-    mapper.registerModule(new Jdk8Module());
+    mapper.findAndRegisterModules();
     return mapper;
   }
 }

--- a/codec-parent/codec-jackson/pom.xml
+++ b/codec-parent/codec-jackson/pom.xml
@@ -23,6 +23,10 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/codec-parent/codec-jackson/src/main/java/io/scalecube/cluster/codec/jackson/DefaultObjectMapper.java
+++ b/codec-parent/codec-jackson/src/main/java/io/scalecube/cluster/codec/jackson/DefaultObjectMapper.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 final class DefaultObjectMapper {
 
@@ -31,6 +32,7 @@ final class DefaultObjectMapper {
         LaissezFaireSubTypeValidator.instance,
         DefaultTyping.JAVA_LANG_OBJECT,
         JsonTypeInfo.As.WRAPPER_OBJECT);
+    mapper.registerModule(new Jdk8Module());
     return mapper;
   }
 }

--- a/codec-parent/codec-jackson/src/main/java/io/scalecube/cluster/codec/jackson/DefaultObjectMapper.java
+++ b/codec-parent/codec-jackson/src/main/java/io/scalecube/cluster/codec/jackson/DefaultObjectMapper.java
@@ -32,7 +32,7 @@ final class DefaultObjectMapper {
         LaissezFaireSubTypeValidator.instance,
         DefaultTyping.JAVA_LANG_OBJECT,
         JsonTypeInfo.As.WRAPPER_OBJECT);
-    mapper.registerModule(new Jdk8Module());
+    mapper.findAndRegisterModules();
     return mapper;
   }
 }

--- a/codec-parent/codec-jackson/src/main/java/io/scalecube/cluster/codec/jackson/DefaultObjectMapper.java
+++ b/codec-parent/codec-jackson/src/main/java/io/scalecube/cluster/codec/jackson/DefaultObjectMapper.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 
-public final class DefaultObjectMapper {
+final class DefaultObjectMapper {
 
   public static final ObjectMapper OBJECT_MAPPER = initMapper();
 

--- a/codec-parent/codec-jackson/src/main/java/io/scalecube/cluster/codec/jackson/DefaultObjectMapper.java
+++ b/codec-parent/codec-jackson/src/main/java/io/scalecube/cluster/codec/jackson/DefaultObjectMapper.java
@@ -27,7 +27,7 @@ final class DefaultObjectMapper {
     mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
     mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     mapper.configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
-    mapper.enableDefaultTyping(
+    mapper.activateDefaultTyping(
         LaissezFaireSubTypeValidator.instance,
         DefaultTyping.JAVA_LANG_OBJECT,
         JsonTypeInfo.As.WRAPPER_OBJECT);

--- a/codec-parent/codec-jackson/src/main/java/io/scalecube/cluster/codec/jackson/DefaultObjectMapper.java
+++ b/codec-parent/codec-jackson/src/main/java/io/scalecube/cluster/codec/jackson/DefaultObjectMapper.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 
-final class DefaultObjectMapper {
+public final class DefaultObjectMapper {
 
   public static final ObjectMapper OBJECT_MAPPER = initMapper();
 

--- a/codec-parent/codec-jackson/src/main/java/io/scalecube/cluster/codec/jackson/DefaultObjectMapper.java
+++ b/codec-parent/codec-jackson/src/main/java/io/scalecube/cluster/codec/jackson/DefaultObjectMapper.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 final class DefaultObjectMapper {
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <slf4j.version>1.7.30</slf4j.version>
     <log4j.version>2.8.2</log4j.version>
     <reactor.version>Dysprosium-RELEASE</reactor.version>
-    <jackson.version>2.10.0.pr1</jackson.version>
+    <jackson.version>2.10.0</jackson.version>
 
     <mockito-junit-jupiter.version>2.27.0</mockito-junit-jupiter.version>
     <junit-jupiter.version>5.1.1</junit-jupiter.version>


### PR DESCRIPTION

* "enableDefaultTyping" is deleted from ObjetMapper and replaced by "activateDefaultTyping" 
*  Change DefaultObjectMapper to public, and allow developers to customize ObjectMapper's configuration.  For example  support CloudEventImpl en/decoding from CloudEvents Java SDK