### PR TITLE
Removed `host` from TransportConfig

### DIFF
--- a/cluster/src/test/java/io/scalecube/cluster/ClusterTest.java
+++ b/cluster/src/test/java/io/scalecube/cluster/ClusterTest.java
@@ -42,7 +42,7 @@ public class ClusterTest extends BaseTest {
             .gossip(opts -> opts.gossipInterval(100))
             .failureDetector(opts -> opts.pingInterval(100))
             .membership(opts -> opts.syncInterval(100))
-            .transport(opts -> opts.host(address.host()).port(address.port()))
+            .transport(opts -> opts.port(address.port()))
             .transport(opts -> opts.connectTimeout(CONNECT_TIMEOUT))
             .startAwait();
 
@@ -67,7 +67,7 @@ public class ClusterTest extends BaseTest {
               .gossip(opts -> opts.gossipInterval(100))
               .failureDetector(opts -> opts.pingInterval(100))
               .membership(opts -> opts.syncInterval(100))
-              .transport(opts -> opts.host(address.host()).port(address.port()))
+              .transport(opts -> opts.port(address.port()))
               .transport(opts -> opts.connectTimeout(CONNECT_TIMEOUT))
               .startAwait();
 

--- a/transport-parent/transport-api/src/main/java/io/scalecube/cluster/transport/api/TransportConfig.java
+++ b/transport-parent/transport-api/src/main/java/io/scalecube/cluster/transport/api/TransportConfig.java
@@ -14,7 +14,6 @@ public final class TransportConfig implements Cloneable {
   // Local cluster working via loopback interface (overrides default/LAN settings)
   public static final int DEFAULT_LOCAL_CONNECT_TIMEOUT = 1_000;
 
-  private String host = null;
   private int port = 0;
   private int connectTimeout = DEFAULT_CONNECT_TIMEOUT;
   private MessageCodec messageCodec = MessageCodec.INSTANCE;
@@ -50,23 +49,7 @@ public final class TransportConfig implements Cloneable {
    * @return new {@code MembershipConfig}
    */
   public static TransportConfig defaultLocalConfig() {
-    return defaultConfig().connectTimeout(DEFAULT_LOCAL_CONNECT_TIMEOUT).host("localhost");
-  }
-
-  public String host() {
-    return host;
-  }
-
-  /**
-   * Sets a host.
-   *
-   * @param host host
-   * @return new {@code TransportConfig} instance
-   */
-  public TransportConfig host(String host) {
-    TransportConfig t = clone();
-    t.host = host;
-    return t;
+    return defaultConfig().connectTimeout(DEFAULT_LOCAL_CONNECT_TIMEOUT);
   }
 
   public int port() {
@@ -145,7 +128,6 @@ public final class TransportConfig implements Cloneable {
   @Override
   public String toString() {
     return new StringJoiner(", ", TransportConfig.class.getSimpleName() + "[", "]")
-        .add("host='" + host + "'")
         .add("port=" + port)
         .add("connectTimeout=" + connectTimeout)
         .add("messageCodec=" + messageCodec)

--- a/transport-parent/transport-netty/src/main/java/io/scalecube/transport/netty/TransportImpl.java
+++ b/transport-parent/transport-netty/src/main/java/io/scalecube/transport/netty/TransportImpl.java
@@ -334,20 +334,13 @@ public final class TransportImpl implements Transport {
    * @return tcp server
    */
   private TcpServer newTcpServer() {
-    TcpServer tcpServer =
-        TcpServer.create()
-            .runOn(loopResources)
-            .option(ChannelOption.TCP_NODELAY, true)
-            .option(ChannelOption.SO_KEEPALIVE, true)
-            .option(ChannelOption.SO_REUSEADDR, true)
-            .port(config.port());
-
-    if (config.host() != null) {
-      tcpServer = tcpServer.host(config.host());
-    }
-
-    return tcpServer.bootstrap(
-        b -> BootstrapHandlers.updateConfiguration(b, "inbound", channelInitializer));
+    return TcpServer.create()
+        .runOn(loopResources)
+        .option(ChannelOption.TCP_NODELAY, true)
+        .option(ChannelOption.SO_KEEPALIVE, true)
+        .option(ChannelOption.SO_REUSEADDR, true)
+        .port(config.port())
+        .bootstrap(b -> BootstrapHandlers.updateConfiguration(b, "inbound", channelInitializer));
   }
 
   /**


### PR DESCRIPTION
**Motivation**

Cluster transport must listen on all addresses (0.0.0.0). 