### PR TITLE
Transport implementation decoupling

### DIFF
--- a/cluster/pom.xml
+++ b/cluster/pom.xml
@@ -23,11 +23,6 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>scalecube-transport-netty</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>scalecube-cluster-api</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -38,6 +33,12 @@
     </dependency>
 
     <!-- Test dependencies -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>scalecube-transport-netty</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>scalecube-cluster-testlib</artifactId>

--- a/cluster/src/main/java/io/scalecube/cluster/ClusterImpl.java
+++ b/cluster/src/main/java/io/scalecube/cluster/ClusterImpl.java
@@ -20,7 +20,6 @@ import io.scalecube.cluster.transport.api.Transport;
 import io.scalecube.cluster.transport.api.TransportConfig;
 import io.scalecube.cluster.transport.api.TransportFactory;
 import io.scalecube.net.Address;
-import io.scalecube.transport.netty.TransportImpl;
 import io.scalecube.utils.ServiceLoaderUtil;
 import java.io.Serializable;
 import java.lang.management.ManagementFactory;
@@ -248,7 +247,7 @@ public final class ClusterImpl implements Cluster {
   }
 
   private Mono<Cluster> doStart0() {
-    return TransportImpl.bind(config.transportConfig())
+    return Transport.bind(config.transportConfig())
         .flatMap(
             boundTransport -> {
               localMember = createLocalMember(boundTransport.address());

--- a/cluster/src/test/java/io/scalecube/cluster/BaseTest.java
+++ b/cluster/src/test/java/io/scalecube/cluster/BaseTest.java
@@ -5,7 +5,6 @@ import io.scalecube.cluster.membership.MembershipProtocolTest;
 import io.scalecube.cluster.transport.api.Transport;
 import io.scalecube.cluster.transport.api.TransportConfig;
 import io.scalecube.cluster.utils.NetworkEmulatorTransport;
-import io.scalecube.transport.netty.TransportImpl;
 import io.scalecube.transport.netty.tcp.TcpTransportFactory;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -53,7 +52,7 @@ public class BaseTest {
 
   protected NetworkEmulatorTransport createTransport(TransportConfig transportConfig) {
     return new NetworkEmulatorTransport(
-        TransportImpl.bindAwait(transportConfig.transportFactory(new TcpTransportFactory())));
+        Transport.bindAwait(transportConfig.transportFactory(new TcpTransportFactory())));
   }
 
   protected void destroyTransport(Transport transport) {

--- a/transport-parent/transport-netty/src/main/java/io/scalecube/transport/netty/TransportImpl.java
+++ b/transport-parent/transport-netty/src/main/java/io/scalecube/transport/netty/TransportImpl.java
@@ -13,7 +13,6 @@ import io.netty.util.ReferenceCountUtil;
 import io.scalecube.cluster.transport.api.Message;
 import io.scalecube.cluster.transport.api.MessageCodec;
 import io.scalecube.cluster.transport.api.Transport;
-import io.scalecube.cluster.transport.api.TransportConfig;
 import io.scalecube.net.Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -25,7 +24,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.Disposable;
 import reactor.core.Disposables;
-import reactor.core.Exceptions;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
@@ -89,52 +87,6 @@ public final class TransportImpl implements Transport {
         .doFinally(s -> onStop.emitEmpty(RETRY_NOT_SERIALIZED))
         .subscribe(
             null, ex -> LOGGER.warn("[{}][doStop] Exception occurred: {}", address, ex.toString()));
-  }
-
-  /**
-   * Init transport with the default configuration synchronously. Starts to accept connections on
-   * local address.
-   *
-   * @return transport
-   */
-  public static Transport bindAwait() {
-    return bindAwait(TransportConfig.defaultConfig());
-  }
-
-  /**
-   * Init transport with the given configuration synchronously. Starts to accept connections on
-   * local address.
-   *
-   * @return transport
-   */
-  public static Transport bindAwait(TransportConfig config) {
-    try {
-      return bind(config).block();
-    } catch (Exception e) {
-      throw Exceptions.propagate(e.getCause() != null ? e.getCause() : e);
-    }
-  }
-
-  /**
-   * Init transport with the default configuration asynchronously. Starts to accept connections on
-   * local address.
-   *
-   * @return promise for bind operation
-   */
-  public static Mono<Transport> bind() {
-    return bind(TransportConfig.defaultConfig());
-  }
-
-  /**
-   * Init transport with the given configuration asynchronously. Starts to accept connections on
-   * local address.
-   *
-   * @param config transport config
-   * @return promise for bind operation
-   */
-  public static Mono<Transport> bind(TransportConfig config) {
-    Objects.requireNonNull(config.transportFactory(), "[bind] transportFactory");
-    return config.transportFactory().createTransport(config).start();
   }
 
   /**

--- a/transport-parent/transport-netty/src/test/java/io/scalecube/transport/netty/BaseTest.java
+++ b/transport-parent/transport-netty/src/test/java/io/scalecube/transport/netty/BaseTest.java
@@ -72,7 +72,7 @@ public class BaseTest {
    */
   protected NetworkEmulatorTransport createTcpTransport() {
     return new NetworkEmulatorTransport(
-        TransportImpl.bindAwait(
+        Transport.bindAwait(
             TransportConfig.defaultConfig().transportFactory(new TcpTransportFactory())));
   }
 
@@ -83,7 +83,7 @@ public class BaseTest {
    */
   protected NetworkEmulatorTransport createWebsocketTransport() {
     return new NetworkEmulatorTransport(
-        TransportImpl.bindAwait(
+        Transport.bindAwait(
             TransportConfig.defaultConfig().transportFactory(new WebsocketTransportFactory())));
   }
 }


### PR DESCRIPTION
Currently, `scalecube-cluster` is dependant on the `scalecube-transport-netty` module even though it might not be needed in case of a custom transport implementation. 
Excluding `scalecube-transport-netty` won't help as TransportImpl from `scalecube-transport-netty` is used in ClusterImpl and `NoClassDefFoundError` will be raised
In this PR I moved transport-netty to test dependencies and also extracted bind methods from `TransportImpl` to `Transport`.
