### PR TITLE
Remove ClusterImpl#isShutdown method

### DIFF
--- a/cluster-api/src/main/java/io/scalecube/cluster/Cluster.java
+++ b/cluster-api/src/main/java/io/scalecube/cluster/Cluster.java
@@ -141,11 +141,4 @@ public interface Cluster {
    * @return promise which is completed once graceful shutdown is finished.
    */
   Mono<Void> onShutdown();
-
-  /**
-   * Check if cluster instance has been shut down.
-   *
-   * @return returns true if cluster instance has been shut down; false otherwise.
-   */
-  boolean isShutdown();
 }

--- a/cluster/src/main/java/io/scalecube/cluster/ClusterImpl.java
+++ b/cluster/src/main/java/io/scalecube/cluster/ClusterImpl.java
@@ -558,11 +558,6 @@ public final class ClusterImpl implements Cluster {
     return onShutdown.asMono();
   }
 
-  @Override
-  public boolean isShutdown() {
-    return onShutdown.asMono().toFuture().isDone();
-  }
-
   private static class SenderAwareTransport implements Transport {
 
     private final Transport transport;

--- a/cluster/src/test/java/io/scalecube/cluster/ClusterTest.java
+++ b/cluster/src/test/java/io/scalecube/cluster/ClusterTest.java
@@ -471,7 +471,6 @@ public class ClusterTest extends BaseTest {
 
     node2.shutdown();
     node2.onShutdown().block(TIMEOUT);
-    assertTrue(node2.isShutdown());
 
     assertTrue(leavingLatch.await(TIMEOUT.getSeconds(), TimeUnit.SECONDS));
     assertTrue(removedLatch.await(TIMEOUT.getSeconds(), TimeUnit.SECONDS));


### PR DESCRIPTION
Method `isShutdown` is potentially dangerous, it can trigger a lot of subscriptions when called frequently. After a discussion in https://github.com/scalecube/scalecube-cluster/pull/372, it was decided to remove this method.