### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,15 +33,15 @@
   </scm>
 
   <properties>
-    <scalecube-commons.version>1.0.18</scalecube-commons.version>
+    <scalecube-commons.version>1.0.19</scalecube-commons.version>
 
-    <slf4j.version>1.7.30</slf4j.version>
-    <log4j.version>2.13.2</log4j.version>
-    <reactor.version>2020.0.10</reactor.version>
-    <jackson.version>2.11.0</jackson.version>
+    <slf4j.version>1.7.36</slf4j.version>
+    <log4j.version>2.17.2</log4j.version>
+    <reactor.version>2020.0.20</reactor.version>
+    <jackson.version>2.13.3</jackson.version>
 
-    <mockito-junit-jupiter.version>2.27.0</mockito-junit-jupiter.version>
-    <junit-jupiter.version>5.1.1</junit-jupiter.version>
+    <mockito-junit-jupiter.version>4.6.1</mockito-junit-jupiter.version>
+    <junit-jupiter.version>5.8.2</junit-jupiter.version>
     <hamcrest.version>1.3</hamcrest.version>
   </properties>
 


### PR DESCRIPTION
Along the way, `io.netty` transitive dependencies are upgraded as well. Current `io.netty` dependencies have CVEs.