### PR TITLE
Adds to infected when gossip received from 2nd and following senders

### DIFF
--- a/cluster/src/main/java/io/scalecube/cluster/gossip/GossipProtocolImpl.java
+++ b/cluster/src/main/java/io/scalecube/cluster/gossip/GossipProtocolImpl.java
@@ -203,13 +203,16 @@ public final class GossipProtocolImpl implements GossipProtocol {
     final long period = this.currentPeriod;
     final GossipRequest gossipRequest = message.data();
     for (Gossip gossip : gossipRequest.gossips()) {
+      GossipState gossipState = null;
       if (ensureSequence(gossip.gossiperId()).add(gossip.sequenceId())) {
-        GossipState gossipState = gossips.get(gossip.gossipId());
+        gossipState = gossips.get(gossip.gossipId());
         if (gossipState == null) { // new gossip
           gossipState = new GossipState(gossip, period);
           gossips.put(gossip.gossipId(), gossipState);
           sink.emitNext(gossip.message(), RETRY_NON_SERIALIZED);
         }
+      }
+      if (gossipState != null) {
         gossipState.addToInfected(gossipRequest.from());
       }
     }


### PR DESCRIPTION
What is happening currently in GossipProtocolImpl.onGossipRequest(Message) is that if the (gossiper, sequence ID) is newly seen, then the sender of the gossip request is added to the gossip state's infected collection.

In a situation where member A originates some gossip, then sends it to members B and C, then B sends the gossip to C, C will not add B to the gossip state's infected collection. As least, this is how it appears to me.

This change adds the sender of the gossip request to the gossip state's infected collection even when the (gossiper, sequence ID) is not newly seen.