### PR TITLE
Make local member ID explicitly configurable via ClusterConfig

### DIFF
--- a/cluster-api/src/main/java/io/scalecube/cluster/ClusterConfig.java
+++ b/cluster-api/src/main/java/io/scalecube/cluster/ClusterConfig.java
@@ -33,6 +33,7 @@ public final class ClusterConfig implements Cloneable {
   private int metadataTimeout = DEFAULT_METADATA_TIMEOUT;
   private MetadataCodec metadataCodec = MetadataCodec.INSTANCE;
 
+  private String memberId;
   private String memberAlias;
   private String externalHost;
   private Integer externalPort;
@@ -156,6 +157,28 @@ public final class ClusterConfig implements Cloneable {
   public ClusterConfig externalHost(String externalHost) {
     ClusterConfig c = clone();
     c.externalHost = externalHost;
+    return c;
+  }
+
+  /**
+   * Returns ID to use for the local member. If {@code null}, the ID will be generated
+   * automatically.
+   *
+   * @return local member ID.
+   */
+  public String memberId() {
+    return memberId;
+  }
+
+  /**
+   * Sets ID to use for the local member. If {@code null}, the ID will be generated automatically.
+   *
+   * @param memberId local member ID
+   * @return new {@code ClusterConfig} instance
+   */
+  public ClusterConfig memberId(String memberId) {
+    ClusterConfig c = clone();
+    c.memberId = memberId;
     return c;
   }
 
@@ -291,6 +314,7 @@ public final class ClusterConfig implements Cloneable {
         .add("metadata=" + metadataAsString())
         .add("metadataTimeout=" + metadataTimeout)
         .add("metadataCodec=" + metadataCodec)
+        .add("memberId='" + memberId + "'")
         .add("memberAlias='" + memberAlias + "'")
         .add("externalHost='" + externalHost + "'")
         .add("externalPort=" + externalPort)

--- a/cluster/src/main/java/io/scalecube/cluster/ClusterImpl.java
+++ b/cluster/src/main/java/io/scalecube/cluster/ClusterImpl.java
@@ -419,7 +419,7 @@ public final class ClusterImpl implements Cluster {
             .orElseGet(() -> Address.create(address.host(), port));
 
     return new Member(
-        UUID.randomUUID().toString(),
+        config.memberId() != null ? config.memberId() : UUID.randomUUID().toString(),
         config.memberAlias(),
         memberAddress,
         config.membershipConfig().namespace());

--- a/cluster/src/test/java/io/scalecube/cluster/ClusterTest.java
+++ b/cluster/src/test/java/io/scalecube/cluster/ClusterTest.java
@@ -587,4 +587,23 @@ public class ClusterTest extends BaseTest {
       LOGGER.error("Exception on cluster shutdown", ex);
     }
   }
+
+  @Test
+  public void testExplicitLocalMemberId() {
+    ClusterConfig config = ClusterConfig.defaultConfig()
+      .memberId("test-member");
+
+    ClusterImpl cluster = null;
+    try {
+      cluster = (ClusterImpl) new ClusterImpl(config)
+        .transportFactory(TcpTransportFactory::new)
+        .startAwait();
+
+      assertEquals("test-member", cluster.member().id());
+    } finally {
+      if (cluster != null) {
+        shutdown(Arrays.asList(cluster));
+      }
+    }
+  }
 }


### PR DESCRIPTION
This unlocks use-cases where member IDs are generated externally