### PR TITLE
Don't clear highest bit in member id string representation

### DIFF
--- a/cluster-api/src/main/java/io/scalecube/cluster/Member.java
+++ b/cluster-api/src/main/java/io/scalecube/cluster/Member.java
@@ -132,7 +132,7 @@ public final class Member implements Externalizable {
   private static String stringifyId(String id) {
     try {
       final UUID uuid = UUID.fromString(id);
-      return Long.toHexString(uuid.getMostSignificantBits() & Long.MAX_VALUE);
+      return Long.toHexString(uuid.getMostSignificantBits());
     } catch (Exception ex) {
       return id;
     }

--- a/cluster/src/test/java/io/scalecube/cluster/MemberTest.java
+++ b/cluster/src/test/java/io/scalecube/cluster/MemberTest.java
@@ -1,0 +1,16 @@
+package io.scalecube.cluster;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+public class MemberTest {
+
+  @Test
+  public void testMemberString() {
+    UUID id = UUID.fromString("879162b5-0300-401a-9df3-18ca1f7df990");
+    Member member = new Member(id.toString(), "alias", "address", "namespace");
+    assertEquals("namespace:alias:879162b50300401a@address", member.toString());
+  }
+}


### PR DESCRIPTION
When looking at the logs that include string representation of the `Member` class, sometimes it's hard to detect differences because highest bit of the member id is cleared for some reason. We still use `toHexString` directly after that so there's no need to do that (if the initial intention was to see only positive values?)