### PR TITLE
feat: implement HTTP transport for node communication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 *.db
 *.csv
 *.log
+apache-maven-3.9.6/

--- a/transport-parent/transport-netty/src/main/java/io/scalecube/transport/netty/http/HttpTransport.java
+++ b/transport-parent/transport-netty/src/main/java/io/scalecube/transport/netty/http/HttpTransport.java
@@ -1,0 +1,242 @@
+package io.scalecube.transport.netty.http;
+
+import static io.scalecube.cluster.transport.api.Transport.parseHost;
+import static io.scalecube.cluster.transport.api.Transport.parsePort;
+import static reactor.core.publisher.Sinks.EmitFailureHandler.busyLooping;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.ByteBufOutputStream;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelOption;
+import io.netty.handler.codec.DecoderException;
+import io.netty.handler.codec.EncoderException;
+import io.scalecube.cluster.transport.api.Message;
+import io.scalecube.cluster.transport.api.Transport;
+import io.scalecube.cluster.transport.api.TransportConfig;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.Disposable;
+import reactor.core.Disposables;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.netty.DisposableServer;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.http.server.HttpServer;
+
+public final class HttpTransport implements Transport {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(HttpTransport.class);
+  private static final reactor.netty.resources.LoopResources LOOP_RESOURCES =
+      reactor.netty.resources.LoopResources.create("sc-cluster-io");
+
+  private final TransportConfig config;
+  private final Sinks.Many<Message> sink = Sinks.many().multicast().directBestEffort();
+
+  // Map to hold HttpClient and ConnectionProvider per destination address
+  private final Map<String, ClientContext> clientContexts = new ConcurrentHashMap<>();
+
+  private DisposableServer server;
+  private String address;
+
+  public HttpTransport(TransportConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public String address() {
+    return address;
+  }
+
+  @Override
+  public Mono<Transport> start() {
+    return HttpServer.create()
+        .runOn(LOOP_RESOURCES)
+        .port(config.port())
+        .childOption(ChannelOption.TCP_NODELAY, true)
+        .childOption(ChannelOption.SO_KEEPALIVE, true)
+        .childOption(ChannelOption.SO_REUSEADDR, true)
+        .handle(
+            (request, response) ->
+                request
+                    .receive()
+                    .aggregate()
+                    .retain()
+                    .doOnNext(this::onMessage)
+                    .then(response.status(200).send().then()))
+        .bind()
+        .doOnNext(this::init)
+        .thenReturn(this);
+  }
+
+  private void init(DisposableServer server) {
+    this.server = server;
+    this.address = prepareAddress(server);
+    LOGGER.info("[start][{}] Bound cluster transport", address);
+  }
+
+  @Override
+  public Mono<Void> stop() {
+    return Mono.defer(
+        () -> {
+          if (server == null) {
+            return Mono.empty();
+          }
+          sink.emitComplete(busyLooping(Duration.ofSeconds(3)));
+          server.dispose();
+          return server
+              .onDispose()
+              .doOnTerminate(
+                  () -> {
+                    clientContexts.values().forEach(ctx -> ctx.connectionProvider.dispose());
+                    clientContexts.clear();
+                  })
+              .doOnSuccess(avoid -> LOGGER.info("[stop][{}] Stopped", address));
+        });
+  }
+
+  @Override
+  public boolean isStopped() {
+    return server != null && server.isDisposed();
+  }
+
+  @Override
+  public Mono<Void> send(String address, Message message) {
+    return clientContexts
+        .computeIfAbsent(address, this::createClientContext)
+        .httpClient
+        .post()
+        .uri("/")
+        .send(Mono.fromCallable(() -> encodeMessage(message)))
+        .responseContent()
+        .then();
+  }
+
+  private ClientContext createClientContext(String address) {
+    reactor.netty.resources.ConnectionProvider connectionProvider =
+        reactor.netty.resources.ConnectionProvider.builder("http-client-" + address)
+            .maxConnections(1)
+            .pendingAcquireMaxCount(-1)
+            .build();
+
+    HttpClient httpClient =
+        HttpClient.create(connectionProvider)
+            .runOn(LOOP_RESOURCES)
+            .host(parseHost(address))
+            .port(parsePort(address))
+            .option(ChannelOption.TCP_NODELAY, true)
+            .option(ChannelOption.SO_KEEPALIVE, true)
+            .option(ChannelOption.SO_REUSEADDR, true)
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, config.connectTimeout())
+            .headers(headers -> headers.set("Content-Type", "application/octet-stream"));
+
+    if (config.isClientSecured()) {
+      httpClient = httpClient.secure();
+    }
+
+    return new ClientContext(httpClient, connectionProvider);
+  }
+
+  private static class ClientContext {
+    final HttpClient httpClient;
+    final reactor.netty.resources.ConnectionProvider connectionProvider;
+
+    ClientContext(
+        HttpClient httpClient, reactor.netty.resources.ConnectionProvider connectionProvider) {
+      this.httpClient = httpClient;
+      this.connectionProvider = connectionProvider;
+    }
+  }
+
+  @Override
+  public Mono<Message> requestResponse(String address, Message request) {
+    return Mono.create(
+        sink -> {
+          Disposable receive =
+              listen()
+                  .filter(resp -> resp.correlationId() != null)
+                  .filter(resp -> resp.correlationId().equals(request.correlationId()))
+                  .take(1)
+                  .subscribe(sink::success, sink::error, sink::success);
+
+          Disposable send =
+              send(address, request)
+                  .subscribe(
+                      null,
+                      ex -> {
+                        receive.dispose();
+                        sink.error(ex);
+                      });
+
+          sink.onDispose(Disposables.composite(send, receive));
+        });
+  }
+
+  @Override
+  public Flux<Message> listen() {
+    return sink.asFlux().onBackpressureBuffer();
+  }
+
+  private void onMessage(ByteBuf byteBuf) {
+    try {
+      if (byteBuf == Unpooled.EMPTY_BUFFER) {
+        return;
+      }
+      if (!byteBuf.isReadable()) {
+        return;
+      }
+      final Message message = decodeMessage(byteBuf);
+      sink.emitNext(message, busyLooping(Duration.ofSeconds(3)));
+    } catch (Exception e) {
+      LOGGER.error("[{}][onMessage] Exception occurred: {}", address, e.toString());
+    }
+  }
+
+  private Message decodeMessage(ByteBuf byteBuf) {
+    try (ByteBufInputStream stream = new ByteBufInputStream(byteBuf, true)) {
+      return config.messageCodec().deserialize(stream);
+    } catch (Exception e) {
+      throw new DecoderException(e);
+    }
+  }
+
+  private ByteBuf encodeMessage(Message message) {
+    ByteBuf byteBuf = ByteBufAllocator.DEFAULT.buffer();
+    ByteBufOutputStream stream = new ByteBufOutputStream(byteBuf);
+    try {
+      config.messageCodec().serialize(message, stream);
+    } catch (Exception e) {
+      byteBuf.release();
+      throw new EncoderException(e);
+    }
+    return byteBuf;
+  }
+
+  private static String prepareAddress(DisposableServer server) {
+    final InetSocketAddress serverAddress = (InetSocketAddress) server.address();
+    final InetAddress inetAddress = serverAddress.getAddress();
+    final int port = serverAddress.getPort();
+
+    if (inetAddress.isAnyLocalAddress()) {
+      return getLocalHostAddress() + ":" + port;
+    } else {
+      return inetAddress.getHostAddress() + ":" + port;
+    }
+  }
+
+  private static String getLocalHostAddress() {
+    try {
+      return InetAddress.getLocalHost().getHostAddress();
+    } catch (UnknownHostException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/transport-parent/transport-netty/src/main/java/io/scalecube/transport/netty/http/HttpTransportFactory.java
+++ b/transport-parent/transport-netty/src/main/java/io/scalecube/transport/netty/http/HttpTransportFactory.java
@@ -1,0 +1,14 @@
+package io.scalecube.transport.netty.http;
+
+import io.scalecube.cluster.transport.api.Transport;
+import io.scalecube.cluster.transport.api.TransportConfig;
+import io.scalecube.cluster.transport.api.TransportFactory;
+import io.scalecube.transport.netty.TransportImpl;
+
+public final class HttpTransportFactory implements TransportFactory {
+
+  @Override
+  public Transport createTransport(TransportConfig config) {
+    return new HttpTransport(config);
+  }
+}

--- a/transport-parent/transport-netty/src/test/java/io/scalecube/transport/netty/BaseTest.java
+++ b/transport-parent/transport-netty/src/test/java/io/scalecube/transport/netty/BaseTest.java
@@ -4,6 +4,7 @@ import io.scalecube.cluster.transport.api.Message;
 import io.scalecube.cluster.transport.api.Transport;
 import io.scalecube.cluster.transport.api.TransportConfig;
 import io.scalecube.cluster.utils.NetworkEmulatorTransport;
+import io.scalecube.transport.netty.http.HttpTransportFactory;
 import io.scalecube.transport.netty.tcp.TcpTransportFactory;
 import io.scalecube.transport.netty.websocket.WebsocketTransportFactory;
 import java.time.Duration;
@@ -70,5 +71,16 @@ public class BaseTest {
     return new NetworkEmulatorTransport(
         Transport.bindAwait(
             TransportConfig.defaultConfig().transportFactory(new WebsocketTransportFactory())));
+  }
+
+  /**
+   * Factory method to create a transport.
+   *
+   * @return tramsprot
+   */
+  protected NetworkEmulatorTransport createHttpTransport() {
+    return new NetworkEmulatorTransport(
+        Transport.bindAwait(
+            TransportConfig.defaultConfig().transportFactory(new HttpTransportFactory())));
   }
 }

--- a/transport-parent/transport-netty/src/test/java/io/scalecube/transport/netty/http/HttpTransportSendOrderTest.java
+++ b/transport-parent/transport-netty/src/test/java/io/scalecube/transport/netty/http/HttpTransportSendOrderTest.java
@@ -1,0 +1,251 @@
+package io.scalecube.transport.netty.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.scalecube.cluster.transport.api.Message;
+import io.scalecube.cluster.transport.api.Transport;
+import io.scalecube.transport.netty.BaseTest;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.LongSummaryStatistics;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.LongStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import reactor.core.Disposable;
+import reactor.core.Exceptions;
+
+public class HttpTransportSendOrderTest extends BaseTest {
+
+  // Auto-destroyed on tear down
+  private Transport client;
+  private Transport server;
+
+  /** Tear down. */
+  @AfterEach
+  public final void tearDown() {
+    destroyTransport(client);
+    destroyTransport(server);
+  }
+
+  @Test
+  public void testSendOrderSingleThreadWithoutPromises(TestInfo testInfo) throws Exception {
+    server = createHttpTransport();
+
+    int iterationNum = 11; // +1 warm up iteration
+    int sentPerIteration = 1000;
+    long[] iterationTimeSeries = new long[iterationNum - 1];
+    for (int i = 0; i < iterationNum; i++) {
+      LOGGER.debug("####### {} : iteration = {}", testInfo.getDisplayName(), i);
+
+      client = createHttpTransport();
+      final List<Message> received = new ArrayList<>();
+      final CountDownLatch latch = new CountDownLatch(sentPerIteration);
+
+      final Disposable serverSubscriber =
+          server
+              .listen()
+              .subscribe(
+                  message -> {
+                    received.add(message);
+                    latch.countDown();
+                  });
+
+      long startAt = System.currentTimeMillis();
+      for (int j = 0; j < sentPerIteration; j++) {
+        Message message = Message.withQualifier("q" + j).build();
+        client
+            .send(server.address(), message)
+            .subscribe(null, th -> LOGGER.error("Failed to send message", th));
+      }
+      latch.await(20, TimeUnit.SECONDS);
+      long iterationTime = System.currentTimeMillis() - startAt;
+      if (i > 0) { // exclude warm up iteration
+        iterationTimeSeries[i - 1] = iterationTime;
+      }
+      assertSendOrder(sentPerIteration, received);
+
+      LOGGER.debug("Iteration time: {} ms", iterationTime);
+
+      serverSubscriber.dispose();
+      destroyTransport(client);
+    }
+
+    LongSummaryStatistics iterationTimeStats =
+        LongStream.of(iterationTimeSeries).summaryStatistics();
+    LOGGER.debug("Iteration time stats (ms): {}", iterationTimeStats);
+  }
+
+  @Test
+  public void testSendOrderSingleThread(TestInfo testInfo) throws Exception {
+    server = createHttpTransport();
+
+    int iterationNum = 11; // +1 warm up iteration
+    int sentPerIteration = 1000;
+    long[] iterationTimeSeries = new long[iterationNum - 1];
+    List<Long> totalSentTimeSeries = new ArrayList<>(sentPerIteration * (iterationNum - 1));
+    for (int i = 0; i < iterationNum; i++) {
+      LOGGER.debug("####### {} : iteration = {}", testInfo.getDisplayName(), i);
+      List<Long> iterSentTimeSeries = new ArrayList<>(sentPerIteration);
+
+      client = createHttpTransport();
+      final List<Message> received = new ArrayList<>();
+      final CountDownLatch latch = new CountDownLatch(sentPerIteration);
+
+      final Disposable serverSubscriber =
+          server
+              .listen()
+              .subscribe(
+                  message -> {
+                    received.add(message);
+                    latch.countDown();
+                  });
+
+      long startAt = System.currentTimeMillis();
+      for (int j = 0; j < sentPerIteration; j++) {
+        long sentAt = System.currentTimeMillis();
+        Message message = Message.withQualifier("q" + j).build();
+        client
+            .send(server.address(), message)
+            .subscribe(
+                avoid -> iterSentTimeSeries.add(System.currentTimeMillis() - sentAt),
+                th ->
+                    LOGGER.error(
+                        "Failed to send message in {} ms",
+                        System.currentTimeMillis() - sentAt,
+                        th));
+      }
+
+      latch.await(20, TimeUnit.SECONDS);
+      long iterationTime = System.currentTimeMillis() - startAt;
+      if (i > 0) { // exclude warm up iteration
+        iterationTimeSeries[i - 1] = iterationTime;
+      }
+      assertSendOrder(sentPerIteration, received);
+
+      Thread.sleep(10); // await a bit for last msg confirmation
+
+      LongSummaryStatistics iterSentTimeStats =
+          iterSentTimeSeries.stream().mapToLong(v -> v).summaryStatistics();
+      if (i == 0) { // warm up iteration
+        LOGGER.debug("Warm up iteration time: {} ms", iterationTime);
+        LOGGER.debug("Sent time stats warm up iter (ms): {}", iterSentTimeStats);
+      } else {
+        totalSentTimeSeries.addAll(iterSentTimeSeries);
+        LongSummaryStatistics totalSentTimeStats =
+            totalSentTimeSeries.stream().mapToLong(v -> v).summaryStatistics();
+        LOGGER.debug("Iteration time: {} ms", iterationTime);
+        LOGGER.debug("Sent time stats iter  (ms): {}", iterSentTimeStats);
+        LOGGER.debug("Sent time stats total (ms): {}", totalSentTimeStats);
+      }
+
+      serverSubscriber.dispose();
+      destroyTransport(client);
+    }
+
+    LongSummaryStatistics iterationTimeStats =
+        LongStream.of(iterationTimeSeries).summaryStatistics();
+    LOGGER.debug("Iteration time stats (ms): {}", iterationTimeStats);
+  }
+
+  @Test
+  public void testSendOrderMultiThread(TestInfo testInfo) throws Exception {
+    Transport server = createHttpTransport();
+
+    final int total = 1000;
+    for (int i = 0; i < 10; i++) {
+      LOGGER.debug("####### {} : iteration = {}", testInfo.getDisplayName(), i);
+      ExecutorService exec =
+          Executors.newFixedThreadPool(
+              4,
+              r -> {
+                Thread thread = new Thread(r);
+                thread.setName("testSendOrderMultiThread");
+                thread.setDaemon(true);
+                return thread;
+              });
+
+      Transport client = createHttpTransport();
+      final List<Message> received = new ArrayList<>();
+      final CountDownLatch latch = new CountDownLatch(4 * total);
+      server
+          .listen()
+          .subscribe(
+              message -> {
+                received.add(message);
+                latch.countDown();
+              });
+
+      final Future<Void> f0 = exec.submit(sender(0, client, server.address(), total));
+      final Future<Void> f1 = exec.submit(sender(1, client, server.address(), total));
+      final Future<Void> f2 = exec.submit(sender(2, client, server.address(), total));
+      final Future<Void> f3 = exec.submit(sender(3, client, server.address(), total));
+
+      latch.await(20, TimeUnit.SECONDS);
+
+      f0.get(1, TimeUnit.SECONDS);
+      f1.get(1, TimeUnit.SECONDS);
+      f2.get(1, TimeUnit.SECONDS);
+      f3.get(1, TimeUnit.SECONDS);
+
+      exec.shutdownNow();
+
+      assertSenderOrder(0, total, received);
+      assertSenderOrder(1, total, received);
+      assertSenderOrder(2, total, received);
+      assertSenderOrder(3, total, received);
+
+      destroyTransport(client);
+    }
+
+    destroyTransport(client);
+    destroyTransport(server);
+  }
+
+  private void assertSendOrder(int total, List<Message> received) {
+    ArrayList<Message> messages = new ArrayList<>(received);
+    assertEquals(total, messages.size());
+    for (int k = 0; k < total; k++) {
+      assertEquals("q" + k, messages.get(k).qualifier());
+    }
+  }
+
+  private Callable<Void> sender(int id, Transport client, String address, int total) {
+    return () -> {
+      for (int j = 0; j < total; j++) {
+        String correlationId = id + "/" + j;
+        try {
+          Message message = Message.withQualifier("q").correlationId(correlationId).build();
+          client.send(address, message).block(Duration.ofSeconds(3));
+        } catch (Exception e) {
+          LOGGER.error("Failed to send message: j = {} id = {}", j, id, e);
+          throw Exceptions.propagate(e);
+        }
+      }
+      return null;
+    };
+  }
+
+  private void assertSenderOrder(int id, int total, List<Message> received) {
+    ArrayList<Message> messages = new ArrayList<>(received);
+    Map<Integer, List<Message>> group = new HashMap<>();
+    for (Message message : messages) {
+      Integer key = Integer.valueOf(message.correlationId().split("/")[0]);
+      group.computeIfAbsent(key, ArrayList::new).add(message);
+    }
+
+    assertEquals(total, group.get(id).size());
+    for (int k = 0; k < total; k++) {
+      assertEquals(id + "/" + k, group.get(id).get(k).correlationId());
+    }
+  }
+}

--- a/transport-parent/transport-netty/src/test/java/io/scalecube/transport/netty/http/HttpTransportTest.java
+++ b/transport-parent/transport-netty/src/test/java/io/scalecube/transport/netty/http/HttpTransportTest.java
@@ -1,0 +1,158 @@
+package io.scalecube.transport.netty.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.scalecube.cluster.transport.api.Message;
+import io.scalecube.cluster.utils.NetworkEmulatorTransport;
+import io.scalecube.transport.netty.BaseTest;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+public class HttpTransportTest extends BaseTest {
+
+  public static final Duration TIMEOUT = Duration.ofSeconds(10);
+
+  // Auto-destroyed on tear down
+  private NetworkEmulatorTransport client;
+  private NetworkEmulatorTransport server;
+
+  /** Tear down. */
+  @AfterEach
+  public final void tearDown() {
+    destroyTransport(client);
+    destroyTransport(server);
+  }
+
+  @Test
+  public void testInteractWithNoConnection(TestInfo testInfo) {
+    String serverAddress = "localhost:49255";
+    for (int i = 0; i < 10; i++) {
+      LOGGER.debug("####### {} : iteration = {}", testInfo.getDisplayName(), i);
+
+      client = createHttpTransport();
+
+      // create transport and don't wait just send message
+      try {
+        Message msg = Message.withData("q").build();
+        client.send(serverAddress, msg).block(Duration.ofSeconds(3));
+        fail("fail");
+      } catch (Exception e) {
+        assertTrue(e.getCause() instanceof IOException, "Unexpected exception type: " + e);
+      }
+
+      // send second message: no connection yet and it's clear that there's no connection
+      try {
+        Message msg = Message.withData("q").build();
+        client.send(serverAddress, msg).block(Duration.ofSeconds(3));
+        fail("fail");
+      } catch (Exception e) {
+        assertTrue(e.getCause() instanceof IOException, "Unexpected exception type: " + e);
+      }
+
+      destroyTransport(client);
+    }
+  }
+
+  @Test
+  public void testPingPongClientTfListenAndServerTfListen() throws Exception {
+    client = createHttpTransport();
+    server = createHttpTransport();
+
+    server
+        .listen()
+        .subscribe(
+            message -> {
+              String address = message.sender();
+              assertEquals(client.address(), address, "Expected clientAddress");
+              send(server, address, Message.fromQualifier("hi client")).subscribe();
+            });
+
+    CompletableFuture<Message> messageFuture = new CompletableFuture<>();
+    client.listen().subscribe(messageFuture::complete);
+
+    send(client, server.address(), Message.fromQualifier("hello server")).subscribe();
+
+    Message result = messageFuture.get(3, TimeUnit.SECONDS);
+    assertNotNull(result, "No response from serverAddress");
+    assertEquals("hi client", result.qualifier());
+  }
+
+  @Test
+  public void testPingPongOnSingleChannel() throws Exception {
+    server = createHttpTransport();
+    client = createHttpTransport();
+
+    server
+        .listen()
+        .buffer(2)
+        .subscribe(
+            messages -> {
+              for (Message message : messages) {
+                Message echo = Message.withData("echo/" + message.qualifier()).build();
+                server
+                    .send(message.sender(), echo)
+                    .subscribe(null, th -> LOGGER.debug("Failed to send message", th));
+              }
+            });
+
+    final CompletableFuture<List<Message>> targetFuture = new CompletableFuture<>();
+    client.listen().buffer(2).subscribe(targetFuture::complete);
+
+    Message q1 = Message.withData("q1").build();
+    Message q2 = Message.withData("q2").build();
+
+    client
+        .send(server.address(), q1)
+        .subscribe(null, th -> LOGGER.error("Failed to send message", th));
+    client
+        .send(server.address(), q2)
+        .subscribe(null, th -> LOGGER.error("Failed to send message", th));
+
+    List<Message> target = targetFuture.get(3, TimeUnit.SECONDS);
+    assertNotNull(target);
+    assertEquals(2, target.size());
+  }
+
+  @Test
+  public void testShouldRequestResponseSuccess() {
+    client = createHttpTransport();
+    server = createHttpTransport();
+
+    server
+        .listen()
+        .filter(req -> req.qualifier().equals("hello/server"))
+        .subscribe(
+            message ->
+                send(
+                        server,
+                        message.sender(),
+                        Message.builder()
+                            .correlationId(message.correlationId())
+                            .data("hello: " + message.data())
+                            .build())
+                    .subscribe());
+
+    String result =
+        client
+            .requestResponse(
+                server.address(),
+                Message.builder()
+                    .qualifier("hello/server")
+                    .correlationId("123xyz")
+                    .data("server")
+                    .build())
+            .map(msg -> msg.data().toString())
+            .block(Duration.ofSeconds(1));
+
+    assertEquals("hello: server", result);
+  }
+}


### PR DESCRIPTION
### Description:

Summary
This PR introduces HTTP Transport as an optional communication layer for ScaleCube. This enables nodes to communicate in restricted environments, specifically behind corporate firewalls that block standard TCP/UDP traffic and only permit outbound/inbound HTTP(S) traffic.

### Rationale
ScaleCube's default transport protocols can be restricted by strict IT policies. By providing an HTTP-based alternative, we ensure:

- Connectivity: Nodes can form clusters across restricted network boundaries.
- Flexibility: Users can choose the transport layer that best fits their infrastructure without changing business logic.

### Changes
- Implemented the `Transport` interface with `HttpTransport`.
- Added integration tests for node-to-node communication over HTTP.