### PR TITLE
Replace hamcrest assertions with JUnit 5 Assertions

### DIFF
--- a/cluster/src/test/java/io/scalecube/cluster/ClusterNamespacesTest.java
+++ b/cluster/src/test/java/io/scalecube/cluster/ClusterNamespacesTest.java
@@ -37,43 +37,43 @@ public class ClusterNamespacesTest extends BaseTest {
   @SuppressWarnings("unused")
   public static Stream<Arguments> testInvalidNamespaceFormat() {
     return Stream.of(
-      of(""),
-      of("  "),
-      of("/abc"),
-      of("a /b /c"),
-      of("a\nb\nc"),
-      of(".abc"),
-      of("abc."),
-      of("a-/b-/c-"),
-      of("a+/b+/c+"),
-      of("abc/"),
-      of("abc/*"),
-      of("abc/."),
-      of("./abc"),
-      of("a./b./c."));
+        of(""),
+        of("  "),
+        of("/abc"),
+        of("a /b /c"),
+        of("a\nb\nc"),
+        of(".abc"),
+        of("abc."),
+        of("a-/b-/c-"),
+        of("a+/b+/c+"),
+        of("abc/"),
+        of("abc/*"),
+        of("abc/."),
+        of("./abc"),
+        of("a./b./c."));
   }
 
   @Test
   public void testSeparateEmptyNamespaces() {
     Cluster root =
-      new ClusterImpl()
-        .transportFactory(WebsocketTransportFactory::new)
-        .membership(opts -> opts.namespace("root"))
-        .startAwait();
+        new ClusterImpl()
+            .transportFactory(WebsocketTransportFactory::new)
+            .membership(opts -> opts.namespace("root"))
+            .startAwait();
 
     Cluster root1 =
-      new ClusterImpl()
-        .transportFactory(WebsocketTransportFactory::new)
-        .membership(opts -> opts.namespace("root1"))
-        .membership(opts -> opts.seedMembers(root.address()))
-        .startAwait();
+        new ClusterImpl()
+            .transportFactory(WebsocketTransportFactory::new)
+            .membership(opts -> opts.namespace("root1"))
+            .membership(opts -> opts.seedMembers(root.address()))
+            .startAwait();
 
     Cluster root2 =
-      new ClusterImpl()
-        .transportFactory(WebsocketTransportFactory::new)
-        .membership(opts -> opts.namespace("root2"))
-        .membership(opts -> opts.seedMembers(root.address()))
-        .startAwait();
+        new ClusterImpl()
+            .transportFactory(WebsocketTransportFactory::new)
+            .membership(opts -> opts.namespace("root2"))
+            .membership(opts -> opts.seedMembers(root.address()))
+            .startAwait();
 
     assertTrue(root.otherMembers().isEmpty());
     assertTrue(root1.otherMembers().isEmpty());
@@ -83,55 +83,55 @@ public class ClusterNamespacesTest extends BaseTest {
   @Test
   public void testSeparateNonEmptyNamespaces() {
     Cluster root =
-      new ClusterImpl()
-        .transportFactory(WebsocketTransportFactory::new)
-        .membership(opts -> opts.namespace("root"))
-        .startAwait();
+        new ClusterImpl()
+            .transportFactory(WebsocketTransportFactory::new)
+            .membership(opts -> opts.namespace("root"))
+            .startAwait();
 
     Cluster bob =
-      new ClusterImpl()
-        .transportFactory(WebsocketTransportFactory::new)
-        .membership(opts -> opts.namespace("root"))
-        .membership(opts -> opts.seedMembers(root.address()))
-        .startAwait();
+        new ClusterImpl()
+            .transportFactory(WebsocketTransportFactory::new)
+            .membership(opts -> opts.namespace("root"))
+            .membership(opts -> opts.seedMembers(root.address()))
+            .startAwait();
 
     Cluster carol =
-      new ClusterImpl()
-        .transportFactory(WebsocketTransportFactory::new)
-        .membership(opts -> opts.namespace("root"))
-        .membership(opts -> opts.seedMembers(root.address(), bob.address()))
-        .startAwait();
+        new ClusterImpl()
+            .transportFactory(WebsocketTransportFactory::new)
+            .membership(opts -> opts.namespace("root"))
+            .membership(opts -> opts.seedMembers(root.address(), bob.address()))
+            .startAwait();
 
     Cluster root2 =
-      new ClusterImpl()
-        .transportFactory(WebsocketTransportFactory::new)
-        .membership(opts -> opts.namespace("root2"))
-        .membership(opts -> opts.seedMembers(root.address()))
-        .startAwait();
+        new ClusterImpl()
+            .transportFactory(WebsocketTransportFactory::new)
+            .membership(opts -> opts.namespace("root2"))
+            .membership(opts -> opts.seedMembers(root.address()))
+            .startAwait();
 
     Cluster dan =
-      new ClusterImpl()
-        .transportFactory(WebsocketTransportFactory::new)
-        .membership(opts -> opts.namespace("root2"))
-        .membership(
-          opts ->
-            opts.seedMembers(
-              root.address(), root2.address(), bob.address(), carol.address()))
-        .startAwait();
+        new ClusterImpl()
+            .transportFactory(WebsocketTransportFactory::new)
+            .membership(opts -> opts.namespace("root2"))
+            .membership(
+                opts ->
+                    opts.seedMembers(
+                        root.address(), root2.address(), bob.address(), carol.address()))
+            .startAwait();
 
     Cluster eve =
-      new ClusterImpl()
-        .transportFactory(WebsocketTransportFactory::new)
-        .membership(opts -> opts.namespace("root2"))
-        .membership(
-          opts ->
-            opts.seedMembers(
-              root.address(),
-              root2.address(),
-              dan.address(),
-              bob.address(),
-              carol.address()))
-        .startAwait();
+        new ClusterImpl()
+            .transportFactory(WebsocketTransportFactory::new)
+            .membership(opts -> opts.namespace("root2"))
+            .membership(
+                opts ->
+                    opts.seedMembers(
+                        root.address(),
+                        root2.address(),
+                        dan.address(),
+                        bob.address(),
+                        carol.address()))
+            .startAwait();
 
     assertContainsInAnyOrder(root.otherMembers(), bob.member(), carol.member());
     assertContainsInAnyOrder(bob.otherMembers(), root.member(), carol.member());
@@ -145,42 +145,42 @@ public class ClusterNamespacesTest extends BaseTest {
   @Test
   public void testSimpleNamespacesHierarchy() {
     Cluster rootDevelop =
-      new ClusterImpl()
-        .transportFactory(WebsocketTransportFactory::new)
-        .membership(opts -> opts.namespace("develop"))
-        .startAwait();
+        new ClusterImpl()
+            .transportFactory(WebsocketTransportFactory::new)
+            .membership(opts -> opts.namespace("develop"))
+            .startAwait();
 
     Cluster bob =
-      new ClusterImpl()
-        .transportFactory(WebsocketTransportFactory::new)
-        .membership(opts -> opts.namespace("develop/develop"))
-        .membership(opts -> opts.seedMembers(rootDevelop.address()))
-        .startAwait();
+        new ClusterImpl()
+            .transportFactory(WebsocketTransportFactory::new)
+            .membership(opts -> opts.namespace("develop/develop"))
+            .membership(opts -> opts.seedMembers(rootDevelop.address()))
+            .startAwait();
 
     Cluster carol =
-      new ClusterImpl()
-        .transportFactory(WebsocketTransportFactory::new)
-        .membership(opts -> opts.namespace("develop/develop"))
-        .membership(opts -> opts.seedMembers(rootDevelop.address(), bob.address()))
-        .startAwait();
+        new ClusterImpl()
+            .transportFactory(WebsocketTransportFactory::new)
+            .membership(opts -> opts.namespace("develop/develop"))
+            .membership(opts -> opts.seedMembers(rootDevelop.address(), bob.address()))
+            .startAwait();
 
     Cluster dan =
-      new ClusterImpl()
-        .transportFactory(WebsocketTransportFactory::new)
-        .membership(opts -> opts.namespace("develop/develop-2"))
-        .membership(
-          opts -> opts.seedMembers(rootDevelop.address(), bob.address(), carol.address()))
-        .startAwait();
+        new ClusterImpl()
+            .transportFactory(WebsocketTransportFactory::new)
+            .membership(opts -> opts.namespace("develop/develop-2"))
+            .membership(
+                opts -> opts.seedMembers(rootDevelop.address(), bob.address(), carol.address()))
+            .startAwait();
 
     Cluster eve =
-      new ClusterImpl()
-        .transportFactory(WebsocketTransportFactory::new)
-        .membership(opts -> opts.namespace("develop/develop-2"))
-        .membership(
-          opts ->
-            opts.seedMembers(
-              rootDevelop.address(), bob.address(), carol.address(), dan.address()))
-        .startAwait();
+        new ClusterImpl()
+            .transportFactory(WebsocketTransportFactory::new)
+            .membership(opts -> opts.namespace("develop/develop-2"))
+            .membership(
+                opts ->
+                    opts.seedMembers(
+                        rootDevelop.address(), bob.address(), carol.address(), dan.address()))
+            .startAwait();
 
     assertContainsInAnyOrder(
       rootDevelop.otherMembers(), bob.member(), carol.member(), dan.member(), eve.member());
@@ -195,55 +195,55 @@ public class ClusterNamespacesTest extends BaseTest {
   @Test
   public void testIsolatedParentNamespaces() {
     Cluster parent1 =
-      new ClusterImpl()
-        .transportFactory(WebsocketTransportFactory::new)
-        .membership(opts -> opts.namespace("a/1"))
-        .startAwait();
+        new ClusterImpl()
+            .transportFactory(WebsocketTransportFactory::new)
+            .membership(opts -> opts.namespace("a/1"))
+            .startAwait();
 
     Cluster bob =
-      new ClusterImpl()
-        .transportFactory(WebsocketTransportFactory::new)
-        .membership(opts -> opts.namespace("a/1/c"))
-        .membership(opts -> opts.seedMembers(parent1.address()))
-        .startAwait();
+        new ClusterImpl()
+            .transportFactory(WebsocketTransportFactory::new)
+            .membership(opts -> opts.namespace("a/1/c"))
+            .membership(opts -> opts.seedMembers(parent1.address()))
+            .startAwait();
 
     Cluster carol =
-      new ClusterImpl()
-        .transportFactory(WebsocketTransportFactory::new)
-        .membership(opts -> opts.namespace("a/1/c"))
-        .membership(opts -> opts.seedMembers(parent1.address(), bob.address()))
-        .startAwait();
+        new ClusterImpl()
+            .transportFactory(WebsocketTransportFactory::new)
+            .membership(opts -> opts.namespace("a/1/c"))
+            .membership(opts -> opts.seedMembers(parent1.address(), bob.address()))
+            .startAwait();
 
     Cluster parent2 =
-      new ClusterImpl()
-        .transportFactory(WebsocketTransportFactory::new)
-        .membership(opts -> opts.namespace("a/111"))
-        .startAwait();
+        new ClusterImpl()
+            .transportFactory(WebsocketTransportFactory::new)
+            .membership(opts -> opts.namespace("a/111"))
+            .startAwait();
 
     Cluster dan =
-      new ClusterImpl()
-        .transportFactory(WebsocketTransportFactory::new)
-        .membership(opts -> opts.namespace("a/111/c"))
-        .membership(
-          opts ->
-            opts.seedMembers(
-              parent1.address(), parent2.address(), bob.address(), carol.address()))
-        .startAwait();
+        new ClusterImpl()
+            .transportFactory(WebsocketTransportFactory::new)
+            .membership(opts -> opts.namespace("a/111/c"))
+            .membership(
+                opts ->
+                    opts.seedMembers(
+                        parent1.address(), parent2.address(), bob.address(), carol.address()))
+            .startAwait();
 
     //noinspection unused
     Cluster eve =
-      new ClusterImpl()
-        .transportFactory(WebsocketTransportFactory::new)
-        .membership(opts -> opts.namespace("a/111/c"))
-        .membership(
-          opts ->
-            opts.seedMembers(
-              parent1.address(),
-              parent2.address(),
-              bob.address(),
-              carol.address(),
-              dan.address()))
-        .startAwait();
+        new ClusterImpl()
+            .transportFactory(WebsocketTransportFactory::new)
+            .membership(opts -> opts.namespace("a/111/c"))
+            .membership(
+                opts ->
+                    opts.seedMembers(
+                        parent1.address(),
+                        parent2.address(),
+                        bob.address(),
+                        carol.address(),
+                        dan.address()))
+            .startAwait();
 
     assertContainsInAnyOrder(parent1.otherMembers(), bob.member(), carol.member());
     assertContainsInAnyOrder(bob.otherMembers(), parent1.member(), carol.member());

--- a/cluster/src/test/java/io/scalecube/cluster/ClusterNamespacesTest.java
+++ b/cluster/src/test/java/io/scalecube/cluster/ClusterNamespacesTest.java
@@ -1,13 +1,12 @@
 package io.scalecube.cluster;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.iterableWithSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.of;
 
 import io.scalecube.transport.netty.websocket.WebsocketTransportFactory;
+import java.util.Collection;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -21,234 +20,240 @@ public class ClusterNamespacesTest extends BaseTest {
   @MethodSource("testInvalidNamespaceFormat")
   public void testInvalidNamespaceFormat(String namespace) {
     Exception actualException =
-        assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                new ClusterImpl()
-                    .transportFactory(WebsocketTransportFactory::new)
-                    .membership(opts -> opts.namespace(namespace))
-                    .startAwait());
-    Assertions.assertAll(
+      assertThrows(
+        IllegalArgumentException.class,
         () ->
-            assertEquals(
-                "Invalid cluster config: membership namespace format is invalid",
-                actualException.getMessage()));
+          new ClusterImpl()
+            .transportFactory(WebsocketTransportFactory::new)
+            .membership(opts -> opts.namespace(namespace))
+            .startAwait());
+    Assertions.assertAll(
+      () ->
+        assertEquals(
+          "Invalid cluster config: membership namespace format is invalid",
+          actualException.getMessage()));
   }
 
   @SuppressWarnings("unused")
   public static Stream<Arguments> testInvalidNamespaceFormat() {
     return Stream.of(
-        of(""),
-        of("  "),
-        of("/abc"),
-        of("a /b /c"),
-        of("a\nb\nc"),
-        of(".abc"),
-        of("abc."),
-        of("a-/b-/c-"),
-        of("a+/b+/c+"),
-        of("abc/"),
-        of("abc/*"),
-        of("abc/."),
-        of("./abc"),
-        of("a./b./c."));
+      of(""),
+      of("  "),
+      of("/abc"),
+      of("a /b /c"),
+      of("a\nb\nc"),
+      of(".abc"),
+      of("abc."),
+      of("a-/b-/c-"),
+      of("a+/b+/c+"),
+      of("abc/"),
+      of("abc/*"),
+      of("abc/."),
+      of("./abc"),
+      of("a./b./c."));
   }
 
   @Test
   public void testSeparateEmptyNamespaces() {
     Cluster root =
-        new ClusterImpl()
-            .transportFactory(WebsocketTransportFactory::new)
-            .membership(opts -> opts.namespace("root"))
-            .startAwait();
+      new ClusterImpl()
+        .transportFactory(WebsocketTransportFactory::new)
+        .membership(opts -> opts.namespace("root"))
+        .startAwait();
 
     Cluster root1 =
-        new ClusterImpl()
-            .transportFactory(WebsocketTransportFactory::new)
-            .membership(opts -> opts.namespace("root1"))
-            .membership(opts -> opts.seedMembers(root.address()))
-            .startAwait();
+      new ClusterImpl()
+        .transportFactory(WebsocketTransportFactory::new)
+        .membership(opts -> opts.namespace("root1"))
+        .membership(opts -> opts.seedMembers(root.address()))
+        .startAwait();
 
     Cluster root2 =
-        new ClusterImpl()
-            .transportFactory(WebsocketTransportFactory::new)
-            .membership(opts -> opts.namespace("root2"))
-            .membership(opts -> opts.seedMembers(root.address()))
-            .startAwait();
+      new ClusterImpl()
+        .transportFactory(WebsocketTransportFactory::new)
+        .membership(opts -> opts.namespace("root2"))
+        .membership(opts -> opts.seedMembers(root.address()))
+        .startAwait();
 
-    assertThat(root.otherMembers(), iterableWithSize(0));
-    assertThat(root1.otherMembers(), iterableWithSize(0));
-    assertThat(root2.otherMembers(), iterableWithSize(0));
+    assertTrue(root.otherMembers().isEmpty());
+    assertTrue(root1.otherMembers().isEmpty());
+    assertTrue(root2.otherMembers().isEmpty());
   }
 
   @Test
   public void testSeparateNonEmptyNamespaces() {
     Cluster root =
-        new ClusterImpl()
-            .transportFactory(WebsocketTransportFactory::new)
-            .membership(opts -> opts.namespace("root"))
-            .startAwait();
+      new ClusterImpl()
+        .transportFactory(WebsocketTransportFactory::new)
+        .membership(opts -> opts.namespace("root"))
+        .startAwait();
 
     Cluster bob =
-        new ClusterImpl()
-            .transportFactory(WebsocketTransportFactory::new)
-            .membership(opts -> opts.namespace("root"))
-            .membership(opts -> opts.seedMembers(root.address()))
-            .startAwait();
+      new ClusterImpl()
+        .transportFactory(WebsocketTransportFactory::new)
+        .membership(opts -> opts.namespace("root"))
+        .membership(opts -> opts.seedMembers(root.address()))
+        .startAwait();
 
     Cluster carol =
-        new ClusterImpl()
-            .transportFactory(WebsocketTransportFactory::new)
-            .membership(opts -> opts.namespace("root"))
-            .membership(opts -> opts.seedMembers(root.address(), bob.address()))
-            .startAwait();
+      new ClusterImpl()
+        .transportFactory(WebsocketTransportFactory::new)
+        .membership(opts -> opts.namespace("root"))
+        .membership(opts -> opts.seedMembers(root.address(), bob.address()))
+        .startAwait();
 
     Cluster root2 =
-        new ClusterImpl()
-            .transportFactory(WebsocketTransportFactory::new)
-            .membership(opts -> opts.namespace("root2"))
-            .membership(opts -> opts.seedMembers(root.address()))
-            .startAwait();
+      new ClusterImpl()
+        .transportFactory(WebsocketTransportFactory::new)
+        .membership(opts -> opts.namespace("root2"))
+        .membership(opts -> opts.seedMembers(root.address()))
+        .startAwait();
 
     Cluster dan =
-        new ClusterImpl()
-            .transportFactory(WebsocketTransportFactory::new)
-            .membership(opts -> opts.namespace("root2"))
-            .membership(
-                opts ->
-                    opts.seedMembers(
-                        root.address(), root2.address(), bob.address(), carol.address()))
-            .startAwait();
+      new ClusterImpl()
+        .transportFactory(WebsocketTransportFactory::new)
+        .membership(opts -> opts.namespace("root2"))
+        .membership(
+          opts ->
+            opts.seedMembers(
+              root.address(), root2.address(), bob.address(), carol.address()))
+        .startAwait();
 
     Cluster eve =
-        new ClusterImpl()
-            .transportFactory(WebsocketTransportFactory::new)
-            .membership(opts -> opts.namespace("root2"))
-            .membership(
-                opts ->
-                    opts.seedMembers(
-                        root.address(),
-                        root2.address(),
-                        dan.address(),
-                        bob.address(),
-                        carol.address()))
-            .startAwait();
+      new ClusterImpl()
+        .transportFactory(WebsocketTransportFactory::new)
+        .membership(opts -> opts.namespace("root2"))
+        .membership(
+          opts ->
+            opts.seedMembers(
+              root.address(),
+              root2.address(),
+              dan.address(),
+              bob.address(),
+              carol.address()))
+        .startAwait();
 
-    assertThat(root.otherMembers(), containsInAnyOrder(bob.member(), carol.member()));
-    assertThat(bob.otherMembers(), containsInAnyOrder(root.member(), carol.member()));
-    assertThat(carol.otherMembers(), containsInAnyOrder(root.member(), bob.member()));
+    assertContainsInAnyOrder(root.otherMembers(), bob.member(), carol.member());
+    assertContainsInAnyOrder(bob.otherMembers(), root.member(), carol.member());
+    assertContainsInAnyOrder(carol.otherMembers(), root.member(), bob.member());
 
-    assertThat(root2.otherMembers(), containsInAnyOrder(dan.member(), eve.member()));
-    assertThat(dan.otherMembers(), containsInAnyOrder(root2.member(), eve.member()));
-    assertThat(eve.otherMembers(), containsInAnyOrder(root2.member(), dan.member()));
+    assertContainsInAnyOrder(root2.otherMembers(), dan.member(), eve.member());
+    assertContainsInAnyOrder(dan.otherMembers(), root2.member(), eve.member());
+    assertContainsInAnyOrder(eve.otherMembers(), root2.member(), dan.member());
   }
 
   @Test
   public void testSimpleNamespacesHierarchy() {
     Cluster rootDevelop =
-        new ClusterImpl()
-            .transportFactory(WebsocketTransportFactory::new)
-            .membership(opts -> opts.namespace("develop"))
-            .startAwait();
+      new ClusterImpl()
+        .transportFactory(WebsocketTransportFactory::new)
+        .membership(opts -> opts.namespace("develop"))
+        .startAwait();
 
     Cluster bob =
-        new ClusterImpl()
-            .transportFactory(WebsocketTransportFactory::new)
-            .membership(opts -> opts.namespace("develop/develop"))
-            .membership(opts -> opts.seedMembers(rootDevelop.address()))
-            .startAwait();
+      new ClusterImpl()
+        .transportFactory(WebsocketTransportFactory::new)
+        .membership(opts -> opts.namespace("develop/develop"))
+        .membership(opts -> opts.seedMembers(rootDevelop.address()))
+        .startAwait();
 
     Cluster carol =
-        new ClusterImpl()
-            .transportFactory(WebsocketTransportFactory::new)
-            .membership(opts -> opts.namespace("develop/develop"))
-            .membership(opts -> opts.seedMembers(rootDevelop.address(), bob.address()))
-            .startAwait();
+      new ClusterImpl()
+        .transportFactory(WebsocketTransportFactory::new)
+        .membership(opts -> opts.namespace("develop/develop"))
+        .membership(opts -> opts.seedMembers(rootDevelop.address(), bob.address()))
+        .startAwait();
 
     Cluster dan =
-        new ClusterImpl()
-            .transportFactory(WebsocketTransportFactory::new)
-            .membership(opts -> opts.namespace("develop/develop-2"))
-            .membership(
-                opts -> opts.seedMembers(rootDevelop.address(), bob.address(), carol.address()))
-            .startAwait();
+      new ClusterImpl()
+        .transportFactory(WebsocketTransportFactory::new)
+        .membership(opts -> opts.namespace("develop/develop-2"))
+        .membership(
+          opts -> opts.seedMembers(rootDevelop.address(), bob.address(), carol.address()))
+        .startAwait();
 
     Cluster eve =
-        new ClusterImpl()
-            .transportFactory(WebsocketTransportFactory::new)
-            .membership(opts -> opts.namespace("develop/develop-2"))
-            .membership(
-                opts ->
-                    opts.seedMembers(
-                        rootDevelop.address(), bob.address(), carol.address(), dan.address()))
-            .startAwait();
+      new ClusterImpl()
+        .transportFactory(WebsocketTransportFactory::new)
+        .membership(opts -> opts.namespace("develop/develop-2"))
+        .membership(
+          opts ->
+            opts.seedMembers(
+              rootDevelop.address(), bob.address(), carol.address(), dan.address()))
+        .startAwait();
 
-    assertThat(
-        rootDevelop.otherMembers(),
-        containsInAnyOrder(bob.member(), carol.member(), dan.member(), eve.member()));
+    assertContainsInAnyOrder(
+      rootDevelop.otherMembers(), bob.member(), carol.member(), dan.member(), eve.member());
 
-    assertThat(bob.otherMembers(), containsInAnyOrder(rootDevelop.member(), carol.member()));
-    assertThat(carol.otherMembers(), containsInAnyOrder(rootDevelop.member(), bob.member()));
+    assertContainsInAnyOrder(bob.otherMembers(), rootDevelop.member(), carol.member());
+    assertContainsInAnyOrder(carol.otherMembers(), rootDevelop.member(), bob.member());
 
-    assertThat(dan.otherMembers(), containsInAnyOrder(rootDevelop.member(), eve.member()));
-    assertThat(eve.otherMembers(), containsInAnyOrder(rootDevelop.member(), dan.member()));
+    assertContainsInAnyOrder(dan.otherMembers(), rootDevelop.member(), eve.member());
+    assertContainsInAnyOrder(eve.otherMembers(), rootDevelop.member(), dan.member());
   }
 
   @Test
   public void testIsolatedParentNamespaces() {
     Cluster parent1 =
-        new ClusterImpl()
-            .transportFactory(WebsocketTransportFactory::new)
-            .membership(opts -> opts.namespace("a/1"))
-            .startAwait();
+      new ClusterImpl()
+        .transportFactory(WebsocketTransportFactory::new)
+        .membership(opts -> opts.namespace("a/1"))
+        .startAwait();
 
     Cluster bob =
-        new ClusterImpl()
-            .transportFactory(WebsocketTransportFactory::new)
-            .membership(opts -> opts.namespace("a/1/c"))
-            .membership(opts -> opts.seedMembers(parent1.address()))
-            .startAwait();
+      new ClusterImpl()
+        .transportFactory(WebsocketTransportFactory::new)
+        .membership(opts -> opts.namespace("a/1/c"))
+        .membership(opts -> opts.seedMembers(parent1.address()))
+        .startAwait();
 
     Cluster carol =
-        new ClusterImpl()
-            .transportFactory(WebsocketTransportFactory::new)
-            .membership(opts -> opts.namespace("a/1/c"))
-            .membership(opts -> opts.seedMembers(parent1.address(), bob.address()))
-            .startAwait();
+      new ClusterImpl()
+        .transportFactory(WebsocketTransportFactory::new)
+        .membership(opts -> opts.namespace("a/1/c"))
+        .membership(opts -> opts.seedMembers(parent1.address(), bob.address()))
+        .startAwait();
 
     Cluster parent2 =
-        new ClusterImpl()
-            .transportFactory(WebsocketTransportFactory::new)
-            .membership(opts -> opts.namespace("a/111"))
-            .startAwait();
+      new ClusterImpl()
+        .transportFactory(WebsocketTransportFactory::new)
+        .membership(opts -> opts.namespace("a/111"))
+        .startAwait();
 
     Cluster dan =
-        new ClusterImpl()
-            .transportFactory(WebsocketTransportFactory::new)
-            .membership(opts -> opts.namespace("a/111/c"))
-            .membership(
-                opts ->
-                    opts.seedMembers(
-                        parent1.address(), parent2.address(), bob.address(), carol.address()))
-            .startAwait();
+      new ClusterImpl()
+        .transportFactory(WebsocketTransportFactory::new)
+        .membership(opts -> opts.namespace("a/111/c"))
+        .membership(
+          opts ->
+            opts.seedMembers(
+              parent1.address(), parent2.address(), bob.address(), carol.address()))
+        .startAwait();
 
     //noinspection unused
     Cluster eve =
-        new ClusterImpl()
-            .transportFactory(WebsocketTransportFactory::new)
-            .membership(opts -> opts.namespace("a/111/c"))
-            .membership(
-                opts ->
-                    opts.seedMembers(
-                        parent1.address(),
-                        parent2.address(),
-                        bob.address(),
-                        carol.address(),
-                        dan.address()))
-            .startAwait();
+      new ClusterImpl()
+        .transportFactory(WebsocketTransportFactory::new)
+        .membership(opts -> opts.namespace("a/111/c"))
+        .membership(
+          opts ->
+            opts.seedMembers(
+              parent1.address(),
+              parent2.address(),
+              bob.address(),
+              carol.address(),
+              dan.address()))
+        .startAwait();
 
-    assertThat(parent1.otherMembers(), containsInAnyOrder(bob.member(), carol.member()));
-    assertThat(bob.otherMembers(), containsInAnyOrder(parent1.member(), carol.member()));
-    assertThat(carol.otherMembers(), containsInAnyOrder(parent1.member(), bob.member()));
+    assertContainsInAnyOrder(parent1.otherMembers(), bob.member(), carol.member());
+    assertContainsInAnyOrder(bob.otherMembers(), parent1.member(), carol.member());
+    assertContainsInAnyOrder(carol.otherMembers(), parent1.member(), bob.member());
+  }
+
+  private static void assertContainsInAnyOrder(Collection<?> collection, Object... items) {
+    assertEquals(items.length, collection.size(), "Collection size mismatch");
+    for (Object item : items) {
+      assertTrue(collection.contains(item), "Collection does not contain: " + item);
+    }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.scalecube</groupId>
     <artifactId>scalecube-parent</artifactId>
-    <version>0.3.18</version>
+    <version>0.3.20-SNAPSHOT</version>
   </parent>
 
   <artifactId>scalecube-cluster-parent</artifactId>
@@ -33,7 +33,7 @@
   </scm>
 
   <properties>
-    <scalecube-test-support.version>0.1.3</scalecube-test-support.version>
+    <scalecube-test-support.version>0.1.5-SNAPSHOT</scalecube-test-support.version>
 
     <distributionManagement.url>https://maven.pkg.github.com/scalecube/scalecube-cluster
     </distributionManagement.url>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.scalecube</groupId>
     <artifactId>scalecube-parent</artifactId>
-    <version>0.3.20-SNAPSHOT</version>
+    <version>0.3.20</version>
   </parent>
 
   <artifactId>scalecube-cluster-parent</artifactId>
@@ -33,7 +33,7 @@
   </scm>
 
   <properties>
-    <scalecube-test-support.version>0.1.5-SNAPSHOT</scalecube-test-support.version>
+    <scalecube-test-support.version>0.1.7</scalecube-test-support.version>
 
     <distributionManagement.url>https://maven.pkg.github.com/scalecube/scalecube-cluster
     </distributionManagement.url>


### PR DESCRIPTION
## Summary
Replaced all hamcrest assertions in scalecube-cluster test code with corresponding JUnit 5 (org.junit.jupiter.api.Assertions) equivalents.
## Changes Made
- Removed hamcrest imports (MatcherAssert, Matchers)
- Replaced assertThat() calls with JUnit 5 equivalents:
  - assertThat(containsInAnyOrder(...)) → assertContainsInAnyOrder() helper method
  - assertThat(iterableWithSize(n)) → assertTrue(isEmpty())
- Added assertContainsInAnyOrder() helper method for collection assertions
