### PR TITLE
Expose the cluster's Transport via Cluster.transport()

### DIFF
--- a/cluster-api/src/main/java/io/scalecube/cluster/Cluster.java
+++ b/cluster-api/src/main/java/io/scalecube/cluster/Cluster.java
@@ -1,6 +1,7 @@
 package io.scalecube.cluster;
 
 import io.scalecube.cluster.transport.api.Message;
+import io.scalecube.cluster.transport.api.Transport;
 import java.util.Collection;
 import java.util.Optional;
 import reactor.core.publisher.Mono;
@@ -14,6 +15,19 @@ public interface Cluster {
    * @return cluster address
    */
   String address();
+
+  /**
+   * Returns the {@link Transport} this cluster instance is bound to — the same transport its
+   * membership, failure-detector, gossip and metadata protocols use. Exposed so embedded layers
+   * (libraries decorating the cluster) can reuse it for their own point-to-point messaging
+   * ({@link Transport#send(String, Message) send} / {@link Transport#requestResponse(String,
+   * Message) requestResponse} / {@link Transport#listen() listen}) instead of binding a second
+   * transport and opening another port. Inbound messages are delivered to the registered {@link
+   * ClusterMessageHandler#onMessage(Message)}.
+   *
+   * @return the cluster's transport
+   */
+  Transport transport();
 
   /**
    * Spreads given message between cluster members using gossiping protocol.

--- a/cluster/src/main/java/io/scalecube/cluster/ClusterImpl.java
+++ b/cluster/src/main/java/io/scalecube/cluster/ClusterImpl.java
@@ -152,6 +152,11 @@ public final class ClusterImpl implements Cluster {
     return cluster;
   }
 
+  @Override
+  public Transport transport() {
+    return transport;
+  }
+
   /**
    * Returns a new cluster's instance which will apply the given options.
    *


### PR DESCRIPTION
## What

Adds a `Transport transport()` accessor to the `Cluster` interface (implemented in `ClusterImpl`, returning the already-bound transport).

## Why

`Cluster` binds exactly one `Transport` — the same one membership, failure-detection, gossip, and metadata all use — but doesn't expose it. The 2.7.x facade is gossip + membership + metadata only (`send`/`requestResponse`/`listen` live on `Transport`, not `Cluster`).

That forces **libraries that decorate a cluster** to bind a *second* transport on another port just to do their own point-to-point RPC — even though inbound messages already surface on the registered `ClusterMessageHandler.onMessage`. They have the receive half but not a way to reach the send half.

Exposing the transport lets an embedded layer reuse the cluster's transport for `send`/`requestResponse`/`listen` (addressing peers by `member.address()`) and **open no extra port**.

### Concrete motivation
[scalecube-prism](https://github.com/scalecube/scalecube-prism) currently borrows this transport by **reflection** to run quorum read-repair without a second port; this accessor replaces that hack with a one-liner.

## Change

- `Cluster`: `Transport transport();` (+ javadoc, + `Transport` import).
- `ClusterImpl`: `@Override public Transport transport() { return transport; }`, placed next to the existing `transport(UnaryOperator<TransportConfig>)` overload (checkstyle `OverloadMethodsDeclarationOrderCheck`).

Purely additive; no behavior change. `cluster-api` + `cluster` compile clean (checkstyle included).

## Note (separate)
The README still shows `cluster.send(member, …)` / `cluster.listen()` examples, which no longer match the slimmed `Cluster` interface (messaging moved to `Transport` in 2.7.x). Happy to follow up with a README fix if useful.
